### PR TITLE
bootstrap package in v4.2 should not be used

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/polyfill": "^7.0.0",
     "@fortawesome/fontawesome-free": "^5.2.0",
     "@netgen/javascript-cookie-control": "^0.0.5",
-    "bootstrap": "^4.1.3",
+    "bootstrap": "~4.1",
     "jquery": "^3.3.1",
     "magnific-popup": "^1.1.0",
     "popper.js": "^1.14.3",


### PR DESCRIPTION
Resolves this problem

```Running webpack ...

WARNING: Invalid value for $grid-breakpoints: This map must be in ascending order, but key 'xxs' has value 0 which isn't greater than 1200px, the value of the previous key 'xl' !
         on line 16 of node_modules/bootstrap/scss/_functions.scss, in mixin `-assert-ascending`
         from line 201 of node_modules/bootstrap/scss/_variables.scss
         from line 9 of src/AppBundle/Resources/sass/bootstrap_import/_bootstrap.scss
         from line 3 of src/AppBundle/Resources/sass/bootstrap_import/_bootstrap_import.scss
         from line 9 of stdin

WARNING: First breakpoint in `$grid-breakpoints` must start at 0, but starts at 480px.
         on line 29 of node_modules/bootstrap/scss/_functions.scss, in mixin `-assert-starts-at-zero`
         from line 202 of node_modules/bootstrap/scss/_variables.scss
         from line 9 of src/AppBundle/Resources/sass/bootstrap_import/_bootstrap.scss
         from line 3 of src/AppBundle/Resources/sass/bootstrap_import/_bootstrap_import.scss
         from line 9 of stdin

 ERROR  Failed to compile with 1 errors                                                                                                                                                                                             12:48:01

 error  in ./src/AppBundle/Resources/sass/style.scss

Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
ModuleBuildError: Module build failed (from ./node_modules/sass-loader/lib/loader.js):

  @return if($next, breakpoint-min($next, $breakpoints) - .02, null);
                   ^
      Invalid null operation: "null sub 0.02".
      in /var/www/html/project/ezplatform/node_modules/bootstrap/scss/mixins/_breakpoints.scss (line 42, column 21)
    at runLoaders (/var/www/html/project/ezplatform/node_modules/webpack/lib/NormalModule.js:301:20)
    at /var/www/html/project/ezplatform/node_modules/loader-runner/lib/LoaderRunner.js:364:11
    at /var/www/html/project/ezplatform/node_modules/loader-runner/lib/LoaderRunner.js:230:18
    at context.callback (/var/www/html/project/ezplatform/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at Object.render [as callback] (/var/www/html/project/ezplatform/node_modules/sass-loader/lib/loader.js:52:13)
    at Object.done [as callback] (/var/www/html/project/ezplatform/node_modules/neo-async/async.js:8077:18)
    at options.error (/var/www/html/project/ezplatform/node_modules/node-sass/lib/index.js:294:32)

 @ ./src/AppBundle/Resources/es6/app.js 129:0-28

Child default:
    Entrypoint app [big] = runtime.js app.js
error Command failed with exit code 2.```