### PR TITLE
Declaration of site_name variable should be moved inside subject block

### DIFF
--- a/src/AppBundle/Resources/views/themes/app/info_collection/email.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/info_collection/email.html.twig
@@ -1,6 +1,5 @@
-{% set site_name = ngsite.siteInfoContent.fields.site_name.value.text|trim %}
-
 {% block subject %}{% spaceless %}
+    {% set site_name = ngsite.siteInfoContent.fields.site_name.value.text|trim %}
     {{ site_name }} – {{ ez_content_name(content) }} [{{ collected_fields.email }}]
 {% endspaceless %}{% endblock %}
 


### PR DESCRIPTION
`subject` block is rendered standalone, separately from the rest of the template so it not aware of `site_name` declaration and one should be moved inside `subject` block.