### PR TITLE
Add is_slider argument to player macro

### DIFF
--- a/src/AppBundle/Resources/views/themes/common/parts/related_multimedia/ng_video.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/parts/related_multimedia/ng_video.html.twig
@@ -3,7 +3,7 @@
 {% if not content.fields.video_file.empty or not content.fields.video_file_hd.empty or not content.fields.video_identifier.empty %}
     {% if is_slider %}
         <div class="swiper-slide">
-            {{ video.player_slide(content, true) }}
+            {{ video.player_slide(content, true, true) }}
         </div>
     {% else %}
         {{ video.player(content, true) }}

--- a/src/AppBundle/Resources/views/themes/common/parts/related_multimedia/ng_video.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/parts/related_multimedia/ng_video.html.twig
@@ -3,7 +3,7 @@
 {% if not content.fields.video_file.empty or not content.fields.video_file_hd.empty or not content.fields.video_identifier.empty %}
     {% if is_slider %}
         <div class="swiper-slide">
-            {{ video.player_slide(content, true, true) }}
+            {{ video.player_slide(content, true) }}
         </div>
     {% else %}
         {{ video.player(content, true) }}

--- a/src/AppBundle/Resources/views/themes/common/parts/video.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/parts/video.html.twig
@@ -48,12 +48,11 @@
     {% endif %}
 {% endmacro %}
 
-{% macro player(content, use_external_embed, is_slider) %}
+{% macro player(content, use_external_embed) %}
     {% set use_external_embed = use_external_embed|default(false) %}
-    {% set is_slider = is_slider|default(false) %}
 
     {% set video_types = content.fields.video_type.value.identifiers %}
-    {% set autoplay = content.fields.autoplay.value.bool and not is_slider %}
+    {% set autoplay = content.fields.autoplay.value.bool %}
 
     {% set image_path = asset('bundles/app/images/video_poster.png') %}
     {% if not content.fields.poster.empty %}

--- a/src/AppBundle/Resources/views/themes/common/parts/video.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/parts/video.html.twig
@@ -48,8 +48,9 @@
     {% endif %}
 {% endmacro %}
 
-{% macro player(content, use_external_embed) %}
+{% macro player(content, use_external_embed, is_slider) %}
     {% set use_external_embed = use_external_embed|default(false) %}
+    {% set is_slider = is_slider|default(false) %}
 
     {% set video_types = content.fields.video_type.value.identifiers %}
     {% set autoplay = content.fields.autoplay.value.bool and not is_slider %}


### PR DESCRIPTION
Autoplay variable inside player macro had is_slider as condiditon but is_slider was not passed as argument.
Also true is now passed from ng_video so it can have same behaviour as earlier.