### PR TITLE
Add Twig type hints to content view templates

### DIFF
--- a/src/AppBundle/Resources/views/themes/app/content/embed/file.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/embed/file.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 <div class="view-type view-type-{{ view_type }} file">
     <div class="file mime-type-{{ content.fields.file.value.mimeType|replace({'/': '-'}) }}">
         {{ ng_render_field(content.fields.file) }}

--- a/src/AppBundle/Resources/views/themes/app/content/embed/image.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/embed/image.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% if not content.fields.image.empty %}
     <div class="view-type view-type-{{ view_type }} image">
         <figure class="image-wrapper">

--- a/src/AppBundle/Resources/views/themes/app/content/embed/ng_article.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/embed/ng_article.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <div class="view-type view-type-{{ view_type }} ng-article">

--- a/src/AppBundle/Resources/views/themes/app/content/embed/ng_audio.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/embed/ng_audio.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <div class="view-type view-type-{{ view_type }} ng-audio">

--- a/src/AppBundle/Resources/views/themes/app/content/embed/ng_banner.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/embed/ng_banner.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import "@ezdesign/parts/macros.html.twig" as macros %}
 
 {% block content %}

--- a/src/AppBundle/Resources/views/themes/app/content/embed/ng_blog_post.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/embed/ng_blog_post.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <div class="view-type view-type-{{ view_type }} ng-blog-post">

--- a/src/AppBundle/Resources/views/themes/app/content/embed/ng_category.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/embed/ng_category.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <div class="view-type view-type-{{ view_type }} ng-category">

--- a/src/AppBundle/Resources/views/themes/app/content/embed/ng_feedback_form.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/embed/ng_feedback_form.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <div class="view-type view-type-{{ view_type }} ng-feedback-form">

--- a/src/AppBundle/Resources/views/themes/app/content/embed/ng_frontpage.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/embed/ng_frontpage.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 <div class="view-type view-type-{{ view_type }} ng-frontpage">
     <h3><a href="{{ path(content) }}">{{ ng_render_field(content.fields.title) }}</a></h3>
 </div>

--- a/src/AppBundle/Resources/views/themes/app/content/embed/ng_gallery.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/embed/ng_gallery.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 <div class="view-type view-type-{{ view_type }} ng-gallery">
     {{ render(
         controller(

--- a/src/AppBundle/Resources/views/themes/app/content/embed/ng_htmlbox.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/embed/ng_htmlbox.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 <div class="view-type view-type-{{ view_type }} ng-htmlbox">
     {{ content.fields.html_code.value.text|raw }}
 </div>

--- a/src/AppBundle/Resources/views/themes/app/content/embed/ng_landing_page.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/embed/ng_landing_page.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <div class="view-type view-type-{{ view_type }} ng-landing-page">

--- a/src/AppBundle/Resources/views/themes/app/content/embed/ng_news.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/embed/ng_news.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <div class="view-type view-type-{{ view_type }} ng-news">

--- a/src/AppBundle/Resources/views/themes/app/content/embed/ng_shortcut.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/embed/ng_shortcut.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import "@ezdesign/parts/macros.html.twig" as macros %}
 
 {% block content %}

--- a/src/AppBundle/Resources/views/themes/app/content/embed/ng_video.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/embed/ng_video.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/video.html.twig' as video %}
 
 <div class="view-type view-type-{{ view_type }} ng-video">

--- a/src/AppBundle/Resources/views/themes/app/content/full/ng_article.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/full/ng_article.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% extends nglayouts.layoutTemplate %}
 
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}

--- a/src/AppBundle/Resources/views/themes/app/content/full/ng_audio.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/full/ng_audio.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% extends nglayouts.layoutTemplate %}
 
 {% if not content.fields.teaser_intro.empty %}

--- a/src/AppBundle/Resources/views/themes/app/content/full/ng_blog_post.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/full/ng_blog_post.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% extends nglayouts.layoutTemplate %}
 
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}

--- a/src/AppBundle/Resources/views/themes/app/content/full/ng_category.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/full/ng_category.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% extends nglayouts.layoutTemplate %}
 
 {% if not content.fields.teaser_intro.empty %}

--- a/src/AppBundle/Resources/views/themes/app/content/full/ng_feedback_form.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/full/ng_feedback_form.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% extends nglayouts.layoutTemplate %}
 
 {% form_theme form '@ezdesign/forms/theme.html.twig' %}

--- a/src/AppBundle/Resources/views/themes/app/content/full/ng_frontpage.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/full/ng_frontpage.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% extends nglayouts.layoutTemplate %}
 
 {% set show_path = false %}

--- a/src/AppBundle/Resources/views/themes/app/content/full/ng_gallery.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/full/ng_gallery.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% extends nglayouts.layoutTemplate %}
 
 {% if not content.fields.teaser_intro.empty %}

--- a/src/AppBundle/Resources/views/themes/app/content/full/ng_htmlbox.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/full/ng_htmlbox.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% extends nglayouts.layoutTemplate %}
 
 {% block content %}

--- a/src/AppBundle/Resources/views/themes/app/content/full/ng_landing_page.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/full/ng_landing_page.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% extends nglayouts.layoutTemplate %}
 
 {% set show_path = false %}

--- a/src/AppBundle/Resources/views/themes/app/content/full/ng_news.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/full/ng_news.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% extends nglayouts.layoutTemplate %}
 
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}

--- a/src/AppBundle/Resources/views/themes/app/content/full/ng_recipe.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/full/ng_recipe.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% extends nglayouts.layoutTemplate %}
 
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}

--- a/src/AppBundle/Resources/views/themes/app/content/full/ng_topic.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/full/ng_topic.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% extends nglayouts.layoutTemplate %}
 
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}

--- a/src/AppBundle/Resources/views/themes/app/content/full/ng_video.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/full/ng_video.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% extends nglayouts.layoutTemplate %}
 
 {% import '@ezdesign/parts/video.html.twig' as video %}

--- a/src/AppBundle/Resources/views/themes/app/content/gallery_grid.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/gallery_grid.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 {% if content.hasField('image') and not content.fields.image.empty %}

--- a/src/AppBundle/Resources/views/themes/app/content/gallery_grid/image.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/gallery_grid/image.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/slide.html.twig' as slide %}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 

--- a/src/AppBundle/Resources/views/themes/app/content/gallery_grid/ng_article.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/gallery_grid/ng_article.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 {% if not content.fields.image.empty %}

--- a/src/AppBundle/Resources/views/themes/app/content/gallery_grid/ng_banner.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/gallery_grid/ng_banner.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 {% if not content.fields.image.empty %}

--- a/src/AppBundle/Resources/views/themes/app/content/gallery_grid/ng_blog_post.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/gallery_grid/ng_blog_post.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 {% if not content.fields.image.empty %}

--- a/src/AppBundle/Resources/views/themes/app/content/gallery_grid/ng_news.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/gallery_grid/ng_news.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 {% if not content.fields.image.empty %}

--- a/src/AppBundle/Resources/views/themes/app/content/gallery_grid/ng_video.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/gallery_grid/ng_video.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import "@ezdesign/parts/video.html.twig" as video %}
 
 {% if not content.fields.video_file.empty or not content.fields.video_file_hd.empty or not content.fields.video_identifier.empty %}

--- a/src/AppBundle/Resources/views/themes/app/content/gallery_thumb.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/gallery_thumb.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/slide.html.twig' as slide %}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 

--- a/src/AppBundle/Resources/views/themes/app/content/gallery_thumb/image.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/gallery_thumb/image.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/slide.html.twig' as slide %}
 
 <div class="view-type view-type-{{ view_type }} image vl3">

--- a/src/AppBundle/Resources/views/themes/app/content/gallery_thumb/ng_article.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/gallery_thumb/ng_article.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 {% import '@ezdesign/parts/slide.html.twig' as slide %}
 

--- a/src/AppBundle/Resources/views/themes/app/content/gallery_thumb/ng_banner.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/gallery_thumb/ng_banner.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/slide.html.twig' as slide %}
 {% import "@ezdesign/parts/macros.html.twig" as macros %}
 

--- a/src/AppBundle/Resources/views/themes/app/content/gallery_thumb/ng_blog_post.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/gallery_thumb/ng_blog_post.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 {% import '@ezdesign/parts/slide.html.twig' as slide %}
 

--- a/src/AppBundle/Resources/views/themes/app/content/gallery_thumb/ng_news.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/gallery_thumb/ng_news.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 {% import '@ezdesign/parts/slide.html.twig' as slide %}
 

--- a/src/AppBundle/Resources/views/themes/app/content/gallery_thumb/ng_video.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/gallery_thumb/ng_video.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import "@ezdesign/parts/video.html.twig" as video %}
 
 {% if not content.fields.video_file.empty or not content.fields.video_file_hd.empty or not content.fields.video_identifier.empty %}

--- a/src/AppBundle/Resources/views/themes/app/content/line.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/line.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} {{ content.contentInfo.contentTypeIdentifier|replace({'_': '-'}) }} vl4">

--- a/src/AppBundle/Resources/views/themes/app/content/line/file.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/line/file.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 <article class="view-type view-type-{{ view_type }} file vl4">
     <div class="article-content">
         <header class="article-header">

--- a/src/AppBundle/Resources/views/themes/app/content/line/ng_article.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/line/ng_article.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-article vl4">

--- a/src/AppBundle/Resources/views/themes/app/content/line/ng_audio.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/line/ng_audio.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-audio vl4">

--- a/src/AppBundle/Resources/views/themes/app/content/line/ng_blog_post.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/line/ng_blog_post.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-blog-post vl4">

--- a/src/AppBundle/Resources/views/themes/app/content/line/ng_category.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/line/ng_category.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-category vl4">

--- a/src/AppBundle/Resources/views/themes/app/content/line/ng_feedback_form.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/line/ng_feedback_form.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-feedback-form vl4">

--- a/src/AppBundle/Resources/views/themes/app/content/line/ng_gallery.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/line/ng_gallery.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 {% set children = location.filterChildren(['image'], 1).currentPageResults %}

--- a/src/AppBundle/Resources/views/themes/app/content/line/ng_landing_page.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/line/ng_landing_page.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-landing-page vl4">

--- a/src/AppBundle/Resources/views/themes/app/content/line/ng_news.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/line/ng_news.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-news vl4">

--- a/src/AppBundle/Resources/views/themes/app/content/line/ng_recipe.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/line/ng_recipe.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-recipe vl4">

--- a/src/AppBundle/Resources/views/themes/app/content/line/ng_video.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/line/ng_video.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 {% import '@ezdesign/parts/video.html.twig' as video %}
 

--- a/src/AppBundle/Resources/views/themes/app/content/listitem.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} {{ content.contentInfo.contentTypeIdentifier|replace({'_': '-'}) }} vl6">

--- a/src/AppBundle/Resources/views/themes/app/content/listitem/file.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem/file.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 <article class="view-type view-type-{{ view_type }} file vl6">
     <h2 class="title">
         <a href="{{ path(location) }}">

--- a/src/AppBundle/Resources/views/themes/app/content/listitem/ng_article.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem/ng_article.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-article vl6">

--- a/src/AppBundle/Resources/views/themes/app/content/listitem/ng_audio.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem/ng_audio.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-audio vl6 t1">

--- a/src/AppBundle/Resources/views/themes/app/content/listitem/ng_blog_post.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem/ng_blog_post.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-blog-post vl6">

--- a/src/AppBundle/Resources/views/themes/app/content/listitem/ng_gallery.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem/ng_gallery.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type-{{ view_type }} ng-gallery vl6 t1">

--- a/src/AppBundle/Resources/views/themes/app/content/listitem/ng_news.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem/ng_news.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-news vl6">

--- a/src/AppBundle/Resources/views/themes/app/content/listitem/ng_recipe.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem/ng_recipe.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-recipe vl6">

--- a/src/AppBundle/Resources/views/themes/app/content/listitem/ng_video.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem/ng_video.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type-{{ view_type }} ng-video vl6 t1">

--- a/src/AppBundle/Resources/views/themes/app/content/mini.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/mini.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} {{ content.contentInfo.contentTypeIdentifier|replace({'_': '-'}) }} vl5">

--- a/src/AppBundle/Resources/views/themes/app/content/mini/file.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/mini/file.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% set location_path = path(location) %}
 
 <article class="view-type view-type-{{ view_type }} file vl5">

--- a/src/AppBundle/Resources/views/themes/app/content/mini/ng_article.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/mini/ng_article.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-article vl5">

--- a/src/AppBundle/Resources/views/themes/app/content/mini/ng_audio.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/mini/ng_audio.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 {% set location_path = path(location) %}

--- a/src/AppBundle/Resources/views/themes/app/content/mini/ng_blog_post.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/mini/ng_blog_post.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-blog-post vl5">

--- a/src/AppBundle/Resources/views/themes/app/content/mini/ng_gallery.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/mini/ng_gallery.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 {% set location_path = path(location) %}

--- a/src/AppBundle/Resources/views/themes/app/content/mini/ng_news.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/mini/ng_news.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-news vl5">

--- a/src/AppBundle/Resources/views/themes/app/content/mini/ng_recipe.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/mini/ng_recipe.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-recipe vl5">

--- a/src/AppBundle/Resources/views/themes/app/content/mini/ng_video.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/mini/ng_video.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 {% import '@ezdesign/parts/video.html.twig' as video %}
 

--- a/src/AppBundle/Resources/views/themes/app/content/overlay.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/overlay.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} {{ content.contentInfo.contentTypeIdentifier|replace({'_': '-'}) }} vl2">

--- a/src/AppBundle/Resources/views/themes/app/content/overlay/ng_article.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/overlay/ng_article.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-article vl2">

--- a/src/AppBundle/Resources/views/themes/app/content/overlay/ng_banner.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/overlay/ng_banner.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 {% import "@ezdesign/parts/macros.html.twig" as macros %}
 

--- a/src/AppBundle/Resources/views/themes/app/content/overlay/ng_blog_post.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/overlay/ng_blog_post.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-blog-post vl2">

--- a/src/AppBundle/Resources/views/themes/app/content/overlay/ng_gallery.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/overlay/ng_gallery.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 {% set children = location.filterChildren(['image'], 1).currentPageResults %}

--- a/src/AppBundle/Resources/views/themes/app/content/overlay/ng_news.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/overlay/ng_news.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-news vl2">

--- a/src/AppBundle/Resources/views/themes/app/content/overlay/ng_recipe.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/overlay/ng_recipe.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-recipe vl2">

--- a/src/AppBundle/Resources/views/themes/app/content/overlay/ng_video.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/overlay/ng_video.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 {% import '@ezdesign/parts/video.html.twig' as video %}
 

--- a/src/AppBundle/Resources/views/themes/app/content/search.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/search.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-search {{ content.contentInfo.contentTypeIdentifier|replace({'_': '-'}) }} vl7">

--- a/src/AppBundle/Resources/views/themes/app/content/slide.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/slide.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/slide.html.twig' as slide %}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 

--- a/src/AppBundle/Resources/views/themes/app/content/slide/image.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/slide/image.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/slide.html.twig' as slide %}
 
 <div class="view-type view-type-{{ view_type }} image vl3">

--- a/src/AppBundle/Resources/views/themes/app/content/slide/ng_article.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/slide/ng_article.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 {% import '@ezdesign/parts/slide.html.twig' as slide %}
 

--- a/src/AppBundle/Resources/views/themes/app/content/slide/ng_banner.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/slide/ng_banner.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/slide.html.twig' as slide %}
 {% import '@ezdesign/parts/macros.html.twig' as macros %}
 

--- a/src/AppBundle/Resources/views/themes/app/content/slide/ng_blog_post.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/slide/ng_blog_post.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 {% import '@ezdesign/parts/slide.html.twig' as slide %}
 

--- a/src/AppBundle/Resources/views/themes/app/content/slide/ng_news.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/slide/ng_news.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 {% import '@ezdesign/parts/slide.html.twig' as slide %}
 

--- a/src/AppBundle/Resources/views/themes/app/content/slide/ng_video.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/slide/ng_video.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 {% import "@ezdesign/parts/video.html.twig" as video %}
 

--- a/src/AppBundle/Resources/views/themes/app/content/standard.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/standard.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} {{ content.contentInfo.contentTypeIdentifier|replace({'_': '-'}) }} vl1">

--- a/src/AppBundle/Resources/views/themes/app/content/standard/file.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/standard/file.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 <article class="view-type view-type-{{ view_type }} file vl1">
 	<header class="article-header">
 	    <h2 class="title">

--- a/src/AppBundle/Resources/views/themes/app/content/standard/image.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/standard/image.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 <article class="view-type view-type-{{ view_type }} image vl1">
     <i class="fas fa-camera article-icon" aria-hidden="true"></i>
 	<figure class="image">

--- a/src/AppBundle/Resources/views/themes/app/content/standard/ng_article.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/standard/ng_article.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-article vl1">

--- a/src/AppBundle/Resources/views/themes/app/content/standard/ng_audio.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/standard/ng_audio.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-audio vl1">

--- a/src/AppBundle/Resources/views/themes/app/content/standard/ng_banner.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/standard/ng_banner.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import "@ezdesign/parts/macros.html.twig" as macros %}
 
 {% block content %}

--- a/src/AppBundle/Resources/views/themes/app/content/standard/ng_blog_post.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/standard/ng_blog_post.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-blog-post vl1">

--- a/src/AppBundle/Resources/views/themes/app/content/standard/ng_category.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/standard/ng_category.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-category vl1">

--- a/src/AppBundle/Resources/views/themes/app/content/standard/ng_feedback_form.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/standard/ng_feedback_form.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-feedback-form vl1">

--- a/src/AppBundle/Resources/views/themes/app/content/standard/ng_frontpage.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/standard/ng_frontpage.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 <article class="view-type view-type-{{ view_type }} ng-frontpage vl1">
     <header class="article-header">
 	    <h2 class="title"><a href="{{ path(location) }}">{{ ng_render_field(content.fields.title) }}</a></h2>

--- a/src/AppBundle/Resources/views/themes/app/content/standard/ng_gallery.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/standard/ng_gallery.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 {% set location_path = path(location) %}

--- a/src/AppBundle/Resources/views/themes/app/content/standard/ng_htmlbox.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/standard/ng_htmlbox.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 <article class="view-type view-type-{{ view_type }} ng-htmlbox vl1">
 	<header class="article-header">
 	    {{ content.fields.html_code.value.text|raw }}

--- a/src/AppBundle/Resources/views/themes/app/content/standard/ng_landing_page.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/standard/ng_landing_page.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-landing-page vl1">

--- a/src/AppBundle/Resources/views/themes/app/content/standard/ng_news.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/standard/ng_news.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-news vl1">

--- a/src/AppBundle/Resources/views/themes/app/content/standard/ng_recipe.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/standard/ng_recipe.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-recipe vl1">

--- a/src/AppBundle/Resources/views/themes/app/content/standard/ng_video.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/standard/ng_video.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 {% import '@ezdesign/parts/video.html.twig' as video %}
 

--- a/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/image.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/image.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 <article class="view-type view-type-{{ view_type }} image vl1">
     <i class="fas fa-camera article-icon" aria-hidden="true"></i>
     <figure class="image">

--- a/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/ng_article.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/ng_article.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-article vl1">

--- a/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/ng_audio.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/ng_audio.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-audio vl1">

--- a/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/ng_banner.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/ng_banner.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import "@ezdesign/parts/macros.html.twig" as macros %}
 
 {% block content %}

--- a/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/ng_blog_post.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/ng_blog_post.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-blog-post vl1">

--- a/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/ng_gallery.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/ng_gallery.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 {% set location_path = path(location) %}

--- a/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/ng_news.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/ng_news.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-news vl1">

--- a/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/ng_recipe.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/ng_recipe.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-recipe vl1">

--- a/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/ng_video.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/content/ngcb_preview/ng_video.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 {% import '@ezdesign/parts/video.html.twig' as video %}
 

--- a/src/AppBundle/Resources/views/themes/common/parts/related_multimedia/image.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/parts/related_multimedia/image.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% if not content.fields.image.empty %}
     {% set image = content.fields.image %}
     {% set image_alias = ng_image_alias(image, 'i1200') %}

--- a/src/AppBundle/Resources/views/themes/common/parts/related_multimedia/ng_banner.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/parts/related_multimedia/ng_banner.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import "@ezdesign/parts/macros.html.twig" as macros %}
 
 {% block content %}

--- a/src/AppBundle/Resources/views/themes/common/parts/related_multimedia/ng_video.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/parts/related_multimedia/ng_video.html.twig
@@ -1,3 +1,5 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 {% import '@ezdesign/parts/video.html.twig' as video %}
 
 {% if not content.fields.video_file.empty or not content.fields.video_file_hd.empty or not content.fields.video_identifier.empty %}


### PR DESCRIPTION
This adds Twig type hints to content view and few part templates, as documented on https://www.jetbrains.com/help/phpstorm/symfony-twig.html#twig-variables