### PR TITLE
NGSTACK-376: disable Legacy Stack Content View fallback

### DIFF
--- a/src/AppBundle/AppBundle.php
+++ b/src/AppBundle/AppBundle.php
@@ -6,6 +6,7 @@ namespace AppBundle;
 
 use AppBundle\DependencyInjection\CompilerPass;
 use Netgen\Bundle\SiteBundle\NetgenSiteProjectBundleInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -13,6 +14,7 @@ final class AppBundle extends Bundle implements NetgenSiteProjectBundleInterface
 {
     public function build(ContainerBuilder $container): void
     {
+        $container->addCompilerPass(new CompilerPass\DisableLegacyContentViewFallbackPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 20);
         $container->addCompilerPass(new CompilerPass\XslRegisterPass());
     }
 }

--- a/src/AppBundle/DependencyInjection/CompilerPass/DisableLegacyContentViewFallbackPass.php
+++ b/src/AppBundle/DependencyInjection/CompilerPass/DisableLegacyContentViewFallbackPass.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class DisableLegacyContentViewFallbackPass implements CompilerPassInterface
+{
+    private const SiteApiLegacyFallbackContentViewProvider = 'netgen_site_legacy.site_api.content_view_provider';
+    private const SiteApiLegacyFallbackLocationViewProvider = 'netgen_site_legacy.site_api.location_view_provider';
+    private const EzPlatformLegacyFallbackContentViewProvider = 'ezpublish_legacy.content_view_provider';
+    private const EzPlatformLegacyFallbackLocationViewProvider = 'ezpublish_legacy.location_view_provider';
+    private const LegacyFallbackApiContentExceptionListener = 'ezpublish_legacy.content_exception_handler';
+
+    public function process(ContainerBuilder $container): void
+    {
+        if ($container->hasDefinition(self::SiteApiLegacyFallbackContentViewProvider)) {
+            $container->removeDefinition(self::SiteApiLegacyFallbackContentViewProvider);
+        }
+
+        if ($container->hasDefinition(self::SiteApiLegacyFallbackLocationViewProvider)) {
+            $container->removeDefinition(self::SiteApiLegacyFallbackLocationViewProvider);
+        }
+
+        if ($container->hasDefinition(self::EzPlatformLegacyFallbackContentViewProvider)) {
+            $container->removeDefinition(self::EzPlatformLegacyFallbackContentViewProvider);
+        }
+
+        if ($container->hasDefinition(self::EzPlatformLegacyFallbackLocationViewProvider)) {
+            $container->removeDefinition(self::EzPlatformLegacyFallbackLocationViewProvider);
+        }
+
+        if ($container->hasDefinition(self::LegacyFallbackApiContentExceptionListener)) {
+            $container->removeDefinition(self::LegacyFallbackApiContentExceptionListener);
+        }
+    }
+}


### PR DESCRIPTION
This disables Legacy Stack Content View fallback for eZ Platform and Site API Content Views.

Because view providers are registered through compiler pass in the `EzPublishCoreBundle`, this first redefines the services without the `ezpublish.view_provider` tag, so they can be removed without the depending services crashing.