### PR TITLE
[WIP] Install NetgenInformationCollection bundle v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
         "netgen/site-installer-bundle": "^2.0@dev",
         "netgen/ezplatform-site-api": "^4.0@dev",
         "netgen/ezplatform-search-extra": "^2.0@dev",
+        "netgen/information-collection-bundle": "^2.0@dev",
 
         "netgen/layouts-standard": "~1.2.0",
         "netgen/layouts-ezplatform": "~1.2.0",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -79,5 +79,6 @@ return [
     Netgen\Bundle\EzPlatformSiteApiBundle\NetgenEzPlatformSiteApiBundle::class => ['all' => true],
     Netgen\Bundle\EzPlatformSearchExtraBundle\NetgenEzPlatformSearchExtraBundle::class => ['all' => true],
     Netgen\Bundle\EzFormsBundle\NetgenEzFormsBundle::class => ['all' => true],
+    Netgen\Bundle\InformationCollectionBundle\NetgenInformationCollectionBundle::class => ['all' => true],
     Snc\RedisBundle\SncRedisBundle::class => ['dev' => true],
 ];


### PR DESCRIPTION
This PR enables the Netgen Information Collection Bundle v2. The state of this PR is still WIP.

Steps to cover:
- [x] Add dependency to `composer.json`
- [x] Enable bundle in `bundles.php`
- [ ] Include routing configuration
- [ ] Include standard semantic configuration
- [ ] Update view template
- [ ] Update email template
- [ ] Review