### PR TITLE
Primary button hover and active state colors

### DIFF
--- a/src/AppBundle/Resources/sass/bootstrap_import/_bootstrap_override.scss
+++ b/src/AppBundle/Resources/sass/bootstrap_import/_bootstrap_override.scss
@@ -15,8 +15,9 @@
     &:not(:disabled):not(.disabled):active,
     &:not(:disabled):not(.disabled).active,
     &:hover {
-        background-color: $gray-87;
-        border-color: $gray-87;
+        background-color: $primary;
+        border-color: $primary;
+        color: $black;
     }
 }
 


### PR DESCRIPTION
Primary buttons had an issue with with hover and active state where background color and text color where the same; 

Hover state is now explicitly set as primary background color and black text color.