### PR TITLE
NGSTACK-458

### DIFF
--- a/src/AppBundle/Resources/views/themes/app/content/full/ng_feedback_form.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/full/ng_feedback_form.html.twig
@@ -58,10 +58,10 @@
                     {{ form_errors(form) }}
 
                     <fieldset>
-                        {{ form_row(form.sender_name, {attr: {class: 'form-control'}}) }}
-                        {{ form_row(form.email, {attr: {class: 'form-control'}}) }}
-                        {{ form_row(form.subject, {attr: {class: 'form-control'}}) }}
-                        {{ form_row(form.message, {attr: {class: 'form-control'}}) }}
+                        {{ form_row(form.sender_name) }}
+                        {{ form_row(form.email)}}
+                        {{ form_row(form.subject) }}
+                        {{ form_row(form.message) }}
 
                         <button type="submit" class="btn btn-primary">{{ 'ngsite.collected_info.button.send'|trans }}</button>
                     </fieldset>

--- a/src/AppBundle/Resources/views/themes/app/forms/theme.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/forms/theme.html.twig
@@ -1,4 +1,4 @@
-{% extends 'form_div_layout.html.twig' %}
+{% extends 'bootstrap_4_layout.html.twig' %}
 
 {%- block form_row -%}
     <div class="form-group {% if errors|length > 0 %}error-input{% endif %}">

--- a/src/AppBundle/Resources/views/themes/app/user/activate.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/user/activate.html.twig
@@ -2,6 +2,8 @@
 
 {% trans_default_domain "ngsite_user" %}
 
+{% form_theme form '@ezdesign/forms/theme.html.twig' %}
+
 {% block content %}
     <div class="page-header">
         <h1>{{ 'ngsite.user.activate.title'|trans }}</h1>
@@ -13,7 +15,7 @@
 
     <fieldset>
         <div class="form-group">
-            {{ form_row(form.email, {'label': 'ngsite.user.activate.email.label', 'attr': {'class': 'form-control'}}) }}
+            {{ form_row(form.email, {'label': 'ngsite.user.activate.email.label'}) }}
         </div>
 
         <button type="submit" class="btn btn-primary">{{ 'ngsite.user.activate.submit'|trans }}</button>

--- a/src/AppBundle/Resources/views/themes/app/user/forgot_password.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/user/forgot_password.html.twig
@@ -2,6 +2,8 @@
 
 {% trans_default_domain "ngsite_user" %}
 
+{% form_theme form '@ezdesign/forms/theme.html.twig' %}
+
 {% block pre_content %}
     <header class="full-page-header full-form-header">
         <div class="container">
@@ -19,7 +21,7 @@
 
         <fieldset>
             <div class="form-group">
-                {{ form_row(form.email, {'label': 'ngsite.user.forgot_password.email.label', 'attr': {'class': 'form-control'}}) }}
+                {{ form_row(form.email, {'label': 'ngsite.user.forgot_password.email.label'}) }}
             </div>
 
             <button type="submit" class="btn btn-primary">{{ 'ngsite.user.forgot_password.submit'|trans }}</button>

--- a/src/AppBundle/Resources/views/themes/app/user/reset_password.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/user/reset_password.html.twig
@@ -2,6 +2,8 @@
 
 {% trans_default_domain "ngsite_user" %}
 
+{% form_theme form '@ezdesign/forms/theme.html.twig' %}
+
 {% block content %}
     <div class="page-header">
         <h1>{{ 'ngsite.user.reset_password.title'|trans }}</h1>
@@ -13,11 +15,11 @@
 
     <fieldset>
         <div class="form-group">
-            {{ form_row(form.password.first, {'label': 'ngsite.user.reset_password.first.label', 'attr': {'class': 'form-control'}}) }}
+            {{ form_row(form.password.first, {'label': 'ngsite.user.reset_password.first.label'}) }}
         </div>
 
         <div class="form-group">
-            {{ form_row(form.password.second, {'label': 'ngsite.user.reset_password.second.label', 'attr': {'class': 'form-control'}}) }}
+            {{ form_row(form.password.second, {'label': 'ngsite.user.reset_password.second.label'}) }}
         </div>
 
         <button type="submit" class="btn btn-primary">{{ 'ngsite.user.reset_password.submit'|trans }}</button>


### PR DESCRIPTION
- change the base Symfony form theme we are extending in the custom form theme from "form_div_layout" to "bootstrap_4_layout". We are using bootstrap 4 in the current website frontend.
- this also solves the visual/markup problem with rendering certain Symfony form fields on the frontend (checkboxes, radio buttons, date and date/time)
- remove form-control CSS class from all form_row elements, it is now added through the theme
- apply custom form theme in all templates where we render Symfony forms.