### PR TITLE
NGSTACK-452 - consolidate overlay ng_banner markup and styling

### DIFF
--- a/src/AppBundle/Resources/config/content_view.yml
+++ b/src/AppBundle/Resources/config/content_view.yml
@@ -38,6 +38,7 @@ frontend_group:
                         - file
                         - ng_article
                         - ng_audio
+                        - ng_banner
                         - ng_blog_post
                         - ng_category
                         - ng_feedback_form
@@ -59,6 +60,7 @@ frontend_group:
                         - file
                         - ng_article
                         - ng_audio
+                        - ng_banner
                         - ng_blog_post
                         - ng_gallery
                         - ng_news
@@ -124,6 +126,7 @@ frontend_group:
                         - file
                         - ng_article
                         - ng_audio
+                        - ng_banner
                         - ng_blog_post
                         - ng_gallery
                         - ng_news

--- a/src/AppBundle/Resources/sass/content/item_view_types/_line.scss
+++ b/src/AppBundle/Resources/sass/content/item_view_types/_line.scss
@@ -5,7 +5,7 @@
     position: relative;
     .image {
         width: 44%;
-        a {
+        a, span {
             display: block;
             position: relative;
             height: 0;

--- a/src/AppBundle/Resources/sass/content/item_view_types/_overlay.scss
+++ b/src/AppBundle/Resources/sass/content/item_view_types/_overlay.scss
@@ -8,31 +8,38 @@
             color: inherit;
         }
     }
-    .image-16by9 {
+    .image {
         display: block;
         position: relative;
         height: 0;
         padding-bottom: 56.25%;
         overflow: hidden;
-        img {
-            object-fit: cover;
-            object-position: center;
-            position: absolute;
-            width: 100%;
-            height: 100%;
-            transition: transform .75s ease-out;
-            will-change: transform;
-        }
-        &::before {
-            content: '';
+        a, span {
             position: absolute;
             left: 0;
             right: 0;
             top: 0;
             bottom: 0;
-            background: linear-gradient(transparent,rgba(0,0,0,0.9));
-            z-index: 2;
-            transition: opacity .75s ease-out;
+            &::before {
+                content: '';
+                position: absolute;
+                left: 0;
+                right: 0;
+                top: 0;
+                bottom: 0;
+                background: linear-gradient(transparent,rgba(0,0,0,0.9));
+                z-index: 1;
+                transition: opacity .75s ease-out;
+            }
+            img {
+                object-fit: cover;
+                object-position: center;
+                position: absolute;
+                width: 100%;
+                height: 100%;
+                transition: transform .75s ease-out;
+                will-change: transform;
+            }
         }
     }
     .article-header {
@@ -81,12 +88,14 @@
     }
     &:hover,
     &:focus {
-        .image-16by9 {
-            &::before {
-                opacity: .75;
-            }
-            img {
-                transform: scale(1.08);
+        .image {
+            a {
+                &::before {
+                    opacity: .75;
+                }
+                img {
+                    transform: scale(1.08);
+                }
             }
         }
     }

--- a/src/AppBundle/Resources/views/themes/app/content/line/ng_banner.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/line/ng_banner.html.twig
@@ -1,0 +1,24 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
+
+{% import "@ezdesign/parts/macros.html.twig" as macros %}
+
+<article class="view-type view-type-{{ view_type }} ng-banner vl4">
+
+    {% if not content.fields.image.empty %}
+        <figure class="image">
+            {{ macros.image_link(content, 'image', 'i480') }}
+        </figure>
+    {% endif %}
+    
+    <div class="article-content">
+        <header class="article-header">
+            <h2 class="title">
+                {{ macros.content_link(content, content.fields.title.value.text) }}
+            </h2>
+        </header>
+        <div class="short">
+            {{ ng_render_field(content.fields.short_description) }}
+        </div>
+    </div>
+</article>

--- a/src/AppBundle/Resources/views/themes/app/content/listitem/ng_banner.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem/ng_banner.html.twig
@@ -1,0 +1,15 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
+
+{% import "@ezdesign/parts/macros.html.twig" as macros %}
+
+<article class="view-type view-type-{{ view_type }} ng-banner vl6">
+	<h2 class="title">
+        {{ macros.content_link(content, content.fields.title.value.text) }}
+    </h2>
+    {% if with_intro|default(false) %}
+        <div class="short">
+            {{ ng_render_field(content.fields.short_description) }}
+        </div>
+    {% endif %}
+</article>

--- a/src/AppBundle/Resources/views/themes/app/content/mini/ng_banner.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/mini/ng_banner.html.twig
@@ -1,0 +1,19 @@
+{# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
+{# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
+
+{% import "@ezdesign/parts/macros.html.twig" as macros %}
+
+<article class="view-type view-type-{{ view_type }} ng-banner vl5">
+
+    {% if not content.fields.image.empty %}
+        <figure class="image">
+            {{ macros.image_link(content, 'image', 'i160') }}
+        </figure>
+    {% endif %}
+
+    <header class="article-header">
+        <h2 class="title">
+            {{ macros.content_link(content, content.fields.title.value.text) }}
+        </h2>
+    </header>
+</article>

--- a/src/AppBundle/Resources/views/themes/app/content/overlay/ng_banner.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/overlay/ng_banner.html.twig
@@ -4,24 +4,16 @@
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 {% import "@ezdesign/parts/macros.html.twig" as macros %}
 
-{% set content_link = macros.content_link_parameters(content) %}
-
 {% block content %}
 <article class="view-type view-type-{{ view_type }} ng-banner vl2">
-    <a {{ content_link }} class="image-16by9" aria-label="{{ not content.fields.url.empty ? content.fields.url.value.text : content.fields.title.value.text|trim }}">
-        {{ content_fields.image(content) }}
-    </a>
-
+    <figure class="image">
+        {{ macros.image_link(content, 'image', 'i480') }}
+    </figure>
     <header class="article-header">
         <h2 class="title">
-            <a {{ content_link }}>
-                {% if not content.fields.url.empty %}
-                    {{ content.fields.url.value.text }}
-                {% else %}
-                    {{ ng_render_field(content.fields.title) }}
-                {% endif %}
-            </a>
+            {{ macros.content_link(content, content.fields.title.value.text) }}
         </h2>
     </header>
+    
 </article>
 {% endblock %}

--- a/src/AppBundle/Resources/views/themes/app/content/overlay/ng_banner.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/overlay/ng_banner.html.twig
@@ -1,7 +1,6 @@
 {# content \Netgen\EzPlatformSiteApi\API\Values\Content #}
 {# location \Netgen\EzPlatformSiteApi\API\Values\Location #}
 
-{% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 {% import "@ezdesign/parts/macros.html.twig" as macros %}
 
 {% block content %}

--- a/src/AppBundle/Resources/views/themes/common/parts/macros.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/parts/macros.html.twig
@@ -31,20 +31,20 @@
     {% endif %}
     {% set lazy_loading = lazy_loading ?? ezpublish.configResolver.getParameter('lazy_loading.enabled', 'ngsite') %}
 
-    {% if not url %}
+    {% if url is not empty %}
         <span>
     {% endif %}
     {{ ng_render_field(
         content.fields[field], {
             'parameters': {
                 'alias': alias,
-                'link_href': url ? url : '',
+                'link_href': url,
                 'link_target': open_in_new_window ? '_blank' : '',
                 'lazy_loading': lazy_loading,
             }
         }
     ) }}
-    {% if not url %}
+    {% if url is not empty %}
         </span>
     {% endif %}
     

--- a/src/AppBundle/Resources/views/themes/common/parts/macros.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/parts/macros.html.twig
@@ -24,35 +24,30 @@
 
 {% macro image_link(content, field, alias, lazy_loading) %}
 {% apply spaceless %}
-    {% set url = _self.related_content_link(content)|trim|default("#") %}
+    {% set url = _self.related_content_link(content)|trim %}
     {% set open_in_new_window = false %}
     {% if content.fields.target_blank.value.bool %}
         {% set open_in_new_window = true %}
     {% endif %}
     {% set lazy_loading = lazy_loading ?? ezpublish.configResolver.getParameter('lazy_loading.enabled', 'ngsite') %}
 
+    {% if not url %}
+        <span>
+    {% endif %}
     {{ ng_render_field(
         content.fields[field], {
             'parameters': {
                 'alias': alias,
-                'link_href': url,
+                'link_href': url ? url : '',
                 'link_target': open_in_new_window ? '_blank' : '',
                 'lazy_loading': lazy_loading,
             }
         }
     ) }}
-{% endapply %}
-{% endmacro %}
-
-{% macro content_link_parameters(content) %}
-{% apply spaceless %}
-    {% set url = _self.related_content_link(content)|trim|default("#") %}
-    {% set open_in_new_window = false %}
-    {% if content.fields.target_blank.value.bool %}
-        {% set open_in_new_window = true %}
+    {% if not url %}
+        </span>
     {% endif %}
-
-    href="{{ url }}"{% if open_in_new_window %} target="_blank" rel="nofollow noopener noreferrer"{% endif %}
+    
 {% endapply %}
 {% endmacro %}
 


### PR DESCRIPTION
Overlay template for ng_banner was much more specific than the rest of the templates for banners, mostly because of different style it has to have (image with overlay, absolutely positioned elements, etc...)

Also, it required a special content_link_parameters macro which was used only on this template, and used as a parameter for link, which looked a bit dirty. 

With this change, overlay ng_banner uses the same macros as other BIVT ng_banner templates, without a need for special requirements.