### PR TITLE
NGSTACK-476 - Add logic for with_intro on listitem_with_intro templates

### DIFF
--- a/src/AppBundle/Resources/views/themes/app/content/listitem/ng_article.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem/ng_article.html.twig
@@ -17,4 +17,8 @@
             <a href="{{ ngsite_topic_path(content.fields.main_topic.value.tags[0]) }}">{{ content.fields.main_topic.value.tags[0].keyword }}</a>
         {% endif %}
     </div>
+    
+    {% if with_intro|default(false) %}
+        {{ content_fields.intro(content) }}
+    {% endif %}
 </article>

--- a/src/AppBundle/Resources/views/themes/app/content/listitem/ng_audio.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem/ng_audio.html.twig
@@ -9,4 +9,8 @@
             <i class="fas fa-volume-up article-icon" aria-hidden="true"></i>{{ content_fields.title(content) }}
         </a>
     </h2>
+
+    {% if with_intro|default(false) %}
+        {{ content_fields.intro(content) }}
+    {% endif %}
 </article>

--- a/src/AppBundle/Resources/views/themes/app/content/listitem/ng_blog_post.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem/ng_blog_post.html.twig
@@ -18,4 +18,8 @@
             <a href="{{ ngsite_topic_path(content.fields.main_topic.value.tags[0]) }}">{{ content.fields.main_topic.value.tags[0].keyword }}</a>
         {% endif %}
     </div>
+
+    {% if with_intro|default(false) %}
+        {{ content_fields.intro(content) }}
+    {% endif %}
 </article>

--- a/src/AppBundle/Resources/views/themes/app/content/listitem/ng_gallery.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem/ng_gallery.html.twig
@@ -16,4 +16,8 @@
             <a href="{{ ngsite_topic_path(content.fields.main_topic.value.tags[0]) }}">{{ content.fields.main_topic.value.tags[0].keyword }}</a>
         {% endif %}
     </div>
+
+    {% if with_intro|default(false) %}
+        {{ content_fields.intro(content) }}
+    {% endif %}
 </article>

--- a/src/AppBundle/Resources/views/themes/app/content/listitem/ng_news.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem/ng_news.html.twig
@@ -18,4 +18,8 @@
             <a href="{{ ngsite_topic_path(content.fields.main_topic.value.tags[0]) }}">{{ content.fields.main_topic.value.tags[0].keyword }}</a>
         {% endif %}
     </div>
+
+    {% if with_intro|default(false) %}
+        {{ content_fields.intro(content) }}
+    {% endif %}
 </article>

--- a/src/AppBundle/Resources/views/themes/app/content/listitem/ng_recipe.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem/ng_recipe.html.twig
@@ -25,4 +25,8 @@
             {% endif %}
         </span>
     </div>
+
+    {% if with_intro|default(false) %}
+        {{ content_fields.intro(content) }}
+    {% endif %}
 </article>

--- a/src/AppBundle/Resources/views/themes/app/content/listitem/ng_video.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/listitem/ng_video.html.twig
@@ -16,4 +16,8 @@
             <a href="{{ ngsite_topic_path(content.fields.main_topic.value.tags[0]) }}">{{ content.fields.main_topic.value.tags[0].keyword }}</a>
         {% endif %}
     </div>
+
+    {% if with_intro|default(false) %}
+        {{ content_fields.intro(content) }}
+    {% endif %}
 </article>


### PR DESCRIPTION
Until now, only fallback listitem template had a logic with with_intro parameter to display the intro. 

All specific templates did not have this, so this PR enables this to make it work.