### PR TITLE
NGSTACK-471 add 'ezpublish_legacy/var/storage' as a shared directory

### DIFF
--- a/deploy/parameters.php
+++ b/deploy/parameters.php
@@ -10,7 +10,7 @@ set('branch', 'master');
 set('repository_name', 'netgen/example');
 
 add('shared_files', ['.env', 'app/config/parameters.yml']);
-add('shared_dirs', ['ezpublish_legacy/var/site/storage']);
+add('shared_dirs', ['ezpublish_legacy/var/site/storage', 'ezpublish_legacy/var/storage']);
 
 add('writable_dirs', ['var/encore', 'ezpublish_legacy/var']);
 set('writable_use_sudo', false);


### PR DESCRIPTION
Tested on titanic, `/var/www/ez/deployment-test`

```
iherak@newtitanic: /var/www/ez/deployment-test $ ll shared/ezpublish_legacy/var/
total 16
drwxr-sr-x 4 deployer www-data 4096 Nov  9 17:42 ./
drwxr-sr-x 3 deployer www-data 4096 Nov  9 17:42 ../
drwxr-sr-x 3 deployer www-data 4096 Nov  9 17:42 site/
drwxr-sr-x 2 deployer www-data 4096 Nov  9 17:42 storage/
```