### PR TITLE
NGSTACK-452 - remove redundant classes and fix grid_featured behaviour

### DIFF
--- a/src/AppBundle/Resources/sass/blocks/list/_grid_featured.scss
+++ b/src/AppBundle/Resources/sass/blocks/list/_grid_featured.scss
@@ -10,7 +10,7 @@
     }
     .vl2 {
         margin: 0;
-        .image-16by9 {
+        .image {
             padding-bottom: 100%;
         }
         .title {
@@ -31,7 +31,7 @@
             flex: 0 0 100%;
             max-width: 100%;
             .vl2 {
-                .image-16by9 {
+                .image {
                     padding-bottom: 56.25%;
                 }
             }
@@ -80,7 +80,7 @@
                     -webkit-line-clamp: 4;
                     max-height: 5em;
                 }
-                .image-16by9 {
+                .image {
                     padding-bottom: 75%;
                 }
             }

--- a/src/AppBundle/Resources/views/themes/app/content/overlay/ng_article.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/overlay/ng_article.html.twig
@@ -4,7 +4,7 @@
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-article vl2">
-    {{ content_fields.image(content, location, null, null, 'image-16by9') }}
+    {{ content_fields.image(content, location) }}
 
     <header class="article-header">
         <h2 class="title"><a href="{{ path(location) }}">{{ content_fields.title(content) }}</a></h2>

--- a/src/AppBundle/Resources/views/themes/app/content/overlay/ng_blog_post.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/overlay/ng_blog_post.html.twig
@@ -5,7 +5,7 @@
 
 <article class="view-type view-type-{{ view_type }} ng-blog-post vl2">
 
-    {{ content_fields.image(content, location, null, null, 'image-16by9') }}
+    {{ content_fields.image(content, location) }}
 
     <header class="article-header">
         <h2 class="title"><a href="{{ path(location) }}">{{ content_fields.title(content) }}</a></h2>

--- a/src/AppBundle/Resources/views/themes/app/content/overlay/ng_gallery.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/overlay/ng_gallery.html.twig
@@ -10,8 +10,8 @@
     {% if children.searchHits is not empty %}
         {% set first_image = children[0].content %}
 
-        <a href="{{ path(location) }}" class="image-16by9" aria-label="{{ first_image.fields.name.value }}">
-            <figure class="image">
+        <figure class="image">
+            <a href="{{ path(location) }}" aria-label="{{ first_image.fields.name.value }}">
                 {{ ng_render_field(
                     first_image.fields.image, {
                         parameters: {
@@ -20,8 +20,8 @@
                         }
                     }
                 ) }}
-            </figure>
-        </a>
+            </a>
+        </figure>
     {% endif %}
 
     <header class="article-header">

--- a/src/AppBundle/Resources/views/themes/app/content/overlay/ng_news.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/overlay/ng_news.html.twig
@@ -4,7 +4,7 @@
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-news vl2">
-    {{ content_fields.image(content, location, null, null, 'image-16by9') }}
+    {{ content_fields.image(content, location) }}
 
     <header class="article-header">
         <h2 class="title"><a href="{{ path(location) }}">{{ content_fields.title(content) }}</a></h2>

--- a/src/AppBundle/Resources/views/themes/app/content/overlay/ng_recipe.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/overlay/ng_recipe.html.twig
@@ -4,7 +4,7 @@
 {% import '@ezdesign/parts/content_fields.html.twig' as content_fields %}
 
 <article class="view-type view-type-{{ view_type }} ng-recipe vl2">
-    {{ content_fields.image(content, location, null, null, 'image-16by9') }}
+    {{ content_fields.image(content, location) }}
 
     <header class="article-header">
         <h2 class="title"><a href="{{ path(location) }}">{{ content_fields.title(content) }}</a></h2>


### PR DESCRIPTION
an issue has occurred from previous changes on overlay templates that specific CSS rules have not been applied to grid_featured block with overlay items in it.

This has been changed, alongside with removal of unnecessary classes on links in overlay templates since this is not necessary anymore (it wasn't necessary even before, but what can you do... :) )