### PR TITLE
Add video poster fix for displaying overlay video template

### DIFF
--- a/src/AppBundle/Resources/views/themes/common/parts/video.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/parts/video.html.twig
@@ -2,8 +2,8 @@
     {% set alias_name = alias_name|default('i480') %}
     {% set alt_text = alt_text ?? null %}
 
-    <a href="{{ path(location is not empty ? location : content) }}" class="image-16by9" {% if alt_text is not empty %}aria-label="{{ alt_text }}"{% endif %}>
-        <figure>
+    <figure class="image">
+        <a href="{{ path(location is not empty ? location : content) }}" class="image-16by9" {% if alt_text is not empty %}aria-label="{{ alt_text }}"{% endif %}>
             {% if not content.fields.poster.empty %}
                 {{ ng_render_field(content.fields.poster, {'parameters': {'alias': alias_name}}) }}
             {% elseif not content.fields.video_identifier.empty %}
@@ -20,8 +20,8 @@
             {% else %}
                     <img data-src="{{ asset('bundles/app/images/video_poster.png') }}" {% if alt_text is not empty %}alt="{{ alt_text }}"{% endif %} />
             {% endif %}
-        </figure>
-    </a>
+        </a>
+    </figure>
 {% endmacro %}
 
 {% macro poster_slide(content, use_lazy_load, alt_text) %}


### PR DESCRIPTION
This microfix has been done in order to display ng_video overlay templates properly, since the major change of banners did not take videos to account.