### PR TITLE
NGSTACK-479 - Add fixes for breadcrumbs

### DIFF
--- a/src/AppBundle/Resources/sass/content/full/_full_page_elements.scss
+++ b/src/AppBundle/Resources/sass/content/full/_full_page_elements.scss
@@ -1,7 +1,10 @@
 .full-page-header {
     background: $primary;
-    padding: 4rem 0;
-    text-align: center;
+    padding: 2rem 0 4rem;
+    margin-bottom: 4rem;
+    &.full-page-header-without-breacrumbs {
+        padding: 4rem 0 4rem;
+    }
     .main-topic, .sponsored-text {
         display: inline-block;
         font-size: .75rem;
@@ -21,6 +24,8 @@
 .full-page-intro {
     color: $black;
     opacity: .54;
+    font-size: 1.3125rem;
+    font-style: italic;
     p {
         margin: 0;
         + p {
@@ -108,12 +113,6 @@
     .object-right > .view-type-embed {
         margin-right: -4rem;
     }
-}
-
-.full-page-intro {
-    font-size: 1.3125rem;
-    font-style: italic;
-    color: $gray-54;
 }
 
 /* full page newsletter box */

--- a/src/AppBundle/Resources/sass/layout/_breadcrumbs.scss
+++ b/src/AppBundle/Resources/sass/layout/_breadcrumbs.scss
@@ -2,9 +2,13 @@
     .breadcrumb {
         background-color: transparent;
         margin: 0;
-        padding: 3rem 0;
+        padding: 1.5rem 0;
         font-size: 1.125rem;
         line-height: 1.3125rem;
-        color: $black;
+        .breadcrumb-item {
+            & + .breadcrumb-item::before {
+                color: inherit;
+            }
+        }
     }
 }

--- a/src/AppBundle/Resources/views/themes/app/content/full/ng_landing_page.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/content/full/ng_landing_page.html.twig
@@ -3,8 +3,6 @@
 
 {% extends nglayouts.layoutTemplate %}
 
-{% set show_path = false %}
-
 {% block content %}
     <div class="view-type view-type-{{ view_type }} ng-landing-page clearfix">
     </div>

--- a/src/AppBundle/Resources/views/themes/app/search/search.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/search/search.html.twig
@@ -4,7 +4,7 @@
 
 {% block content %}
     <form action="{{ path('ngsite_content_search') }}" method="get" class="form-search">
-        <header class="full-page-header full-search-header">
+        <header class="full-page-header full-search-header full-page-header-without-breacrumbs">
             <div class="container">
                 <div class="search-inputs">
                     <div class="input-group">

--- a/src/AppBundle/Resources/views/themes/app/tag/view.html.twig
+++ b/src/AppBundle/Resources/views/themes/app/tag/view.html.twig
@@ -7,13 +7,13 @@
 {% set site_title = tag_keyword %}
 
 {% block content %}
-    <header class="full-page-header">
+    <header class="full-page-header full-page-header-without-breacrumbs">
         <div class="container">
             <h1 class="full-page-title">{{ tag_keyword }}</h1>
         </div>
     </header>
 
-    <div class="full-tag-results">
+    <div class="container">
         {% if related_content|length > 0 %}
             <div class="row">
                 {% for related_content_item in related_content %}


### PR DESCRIPTION
This PR has:

1. fixes on breadcrumbs styling
2. enable of breadcrumbs on landing pages by default
3. provide styling for pages that cannot have breadcrumbs (search, tags view)
4. content fixes on Layouts to make the default state look nice.

LAYOUT CHANGES:

Landing Page / Fitness,
Landing Page / Healthy Eating:

all changes are on first container block/content inside it

- container: change whitespace top from medium to small
- main title: change from Title (Centered) to Title
- Text below main title: change from align center to align left