### PR TITLE
Remove JSON extesion from the list dependencies

### DIFF
--- a/doc/netgen/INSTALL.md
+++ b/doc/netgen/INSTALL.md
@@ -6,7 +6,7 @@ Software requirements
 
 * PHP built in server / Apache 2.4+ / Nginx 1.12+
 * MySQL 5.7+
-* PHP 7.3+ (with `gd`, `imagick`, `curl`, `json`, `mysql`, `xsl`, `xml`, `intl` and `mbstring` extensions)
+* PHP 7.3+ (with `gd`, `imagick`, `curl`, `mysql`, `xsl`, `xml`, `intl` and `mbstring` extensions)
 * ImageMagick
 
 Optional dependencies


### PR DESCRIPTION
JSON extension is compiled into PHP by default since 5.2.0, and it's unnecessary to explicitly mention it.

See: https://www.php.net/manual/en/json.installation.php