### PR TITLE
NGSTACK-496 remove assets from git and make sure deployer builds them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,10 +33,9 @@ node_modules/
 !var/encore/.gitkeep
 /vendor/
 /web/assets/app/*
-!/web/assets/app/build/
 /web/assets/build/*
 /web/assets/ezplatform/*
-!/web/assets/ezplatform/build/
+/web/assets/translations/*
 /web/bundles/
 /web/design
 /web/extension

--- a/.gitignore
+++ b/.gitignore
@@ -32,10 +32,7 @@ node_modules/
 /var/encore/*
 !var/encore/.gitkeep
 /vendor/
-/web/assets/app/*
-/web/assets/build/*
-/web/assets/ezplatform/*
-/web/assets/translations/*
+/web/assets
 /web/bundles/
 /web/design
 /web/extension

--- a/deploy.php
+++ b/deploy.php
@@ -16,6 +16,8 @@ require __DIR__ . '/deploy/tasks/deploy_log.php';
 require __DIR__ . '/deploy/tasks/sentry.php';
 require __DIR__ . '/deploy/tasks/logs.php';
 require __DIR__ . '/deploy/tasks/overrides.php';
+require __DIR__ . '/deploy/tasks/assets.php';
+require __DIR__ . '/deploy/tasks/app.php';
 require __DIR__ . '/deploy/parameters.php';
 // optional: slack integration
 //require __DIR__ . '/deploy/tasks/slack.php';

--- a/deploy/tasks/app.php
+++ b/deploy/tasks/app.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Deployer;
+
+// put your application specific tasks here

--- a/deploy/tasks/assets.php
+++ b/deploy/tasks/assets.php
@@ -7,7 +7,6 @@ set('asset_resource_paths', [
     'src/AppBundle/Resources/es6',
     'src/AppBundle/Resources/sass'
 ]);
-set('asset_build_base', 'web');
 set('asset_build_paths', [
     'assets',
 ]);
@@ -52,6 +51,6 @@ task('assets:upload', function() {
     }
 
     foreach ($assetPaths as $path) {
-        upload("{{asset_build_base}}/{$path}", '{{release_path}}/{{asset_build_base}}', $config);
+        upload("web/{$path}", '{{release_path}}/web', $config);
     }
 });

--- a/deploy/tasks/assets.php
+++ b/deploy/tasks/assets.php
@@ -14,7 +14,7 @@ set('asset_exclude_paths', [
    'assets/app/build_dev'
 ]);
 set('asset_install_command', 'yarn install');
-set('asset_build_command', 'yarn encore production');
+set('asset_build_command', 'yarn build:prod');
 set('asset_ezplatform_build_command', 'composer ezplatform-assets');
 
 task('assets:deploy', [

--- a/deploy/tasks/assets.php
+++ b/deploy/tasks/assets.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Deployer;
+
+// parameters
+set('asset_resource_paths', [
+    'src/AppBundle/Resources/es6',
+    'src/AppBundle/Resources/sass'
+]);
+set('asset_build_base', 'web');
+set('asset_build_paths', [
+    'assets',
+]);
+set('asset_exclude_paths', [
+   'assets/app/build_dev'
+]);
+set('asset_install_command', 'yarn install');
+set('asset_build_command', 'yarn encore production');
+set('asset_ezplatform_build_command', 'composer ezplatform-assets');
+
+task('assets:deploy', [
+    'assets:build',
+    'assets:ezplatform:build',
+    'assets:upload'
+]);
+
+task('assets:build', function() {
+    writeln('<comment>Checking for changes in asset files. If this fails, commit or stash your changes before deploying.</comment>');
+    $assetResourcePaths = get('asset_resource_paths');
+    foreach ($assetResourcePaths as $resourcePath) {
+        run("git diff --exit-code {$resourcePath}");
+    }
+
+    $installCmd = get('asset_install_command');
+    run($installCmd);
+
+    $buildCmd = get('asset_build_command');
+    run($buildCmd);
+})->local();
+
+task('assets:ezplatform:build', function() {
+    run("{{asset_ezplatform_build_command}}");
+})->local();
+
+task('assets:upload', function() {
+    $assetPaths = get('asset_build_paths');
+    $excludedPaths = get('asset_exclude_paths', []);
+
+    $config = [];
+    foreach ($excludedPaths as $excludedPath) {
+        $config['options'][] = "--exclude {$excludedPath}";
+    }
+
+    foreach ($assetPaths as $path) {
+        upload("{{asset_build_base}}/{$path}", '{{release_path}}/{{asset_build_base}}', $config);
+    }
+});

--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
         ]
     },
     "scripts": {
-        "dev": "encore dev",
         "build:dev": "encore dev",
-        "prod": "encore production",
         "build:prod": "encore production",
         "watch": "encore dev --watch",
         "start": "encore dev-server",


### PR DESCRIPTION
With this change, we would not keep production asset builds in the repository any more, but rather have deployer build them locally, and upload them to the server on deploy.

Important parameters:
* `asset_resource_paths` - paths to folders which hold the sources from which the assets are build. These paths are checked for changes before build, and if there are some local uncommitted changes, will not allow deploy to go further.
* `asset_build_base` - web or public, depending on symfony version
* `asset_build_paths` - paths of all the folders within base which should be uploaded
* `asset_exclude_paths` - files or folders which are to be excluded from the upload (typically `assets/app/build_dev`)
