### PR TITLE
Document the password of the administrator user from the demo data

### DIFF
--- a/doc/netgen/INSTALL.md
+++ b/doc/netgen/INSTALL.md
@@ -118,6 +118,9 @@ php bin/console ibexa:install <SITE_NAME>
 where `<SITE_NAME>` is the name of wanted site, e.g. `netgen-media`,
 or `netgen-media-clean` for the clean version, without demo data.
 
+Both of these sets of demo data add an administrator user to the database.
+This user's username is `admin` and its password is `publish`.
+
 Finally, generate the GraphQL schema for admin interface:
 
 ```


### PR DESCRIPTION
The demo data adds an administrator user to the database, but the password for the account is not documented anywhere.

This pull requests adds the username and password to the install instructions, in the section on importing the database schema and demo data.