### PR TITLE
NGSTACK-537 deploy assets fix

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -55,7 +55,7 @@ task('deploy', [
     'deploy:create_cache_dir',
     'deploy:shared',
     // build and upload assets
-    'assets:deploy',
+    'app:assets:deploy',
     // symfony recipe - set asset timestamp (see https://github.com/deployphp/deployer/blob/6.x/recipe/symfony.php#L85)
     'deploy:assets',
     // copy vendors folder between releases before running composer install to speed it up

--- a/deploy.php
+++ b/deploy.php
@@ -54,6 +54,9 @@ task('deploy', [
     'deploy:clear_paths',
     'deploy:create_cache_dir',
     'deploy:shared',
+    // build and upload assets
+    'assets:deploy',
+    // symfony recipe - set asset timestamp (see https://github.com/deployphp/deployer/blob/6.x/recipe/symfony.php#L85)
     'deploy:assets',
     // copy vendors folder between releases before running composer install to speed it up
     'deploy:copy_dirs',

--- a/deploy/tasks/assets.php
+++ b/deploy/tasks/assets.php
@@ -15,7 +15,11 @@ set('asset_exclude_paths', [
 ]);
 set('asset_install_command', 'yarn install');
 set('asset_build_command', 'yarn build:prod');
-set('asset_ezplatform_build_command', 'composer ezplatform-assets');
+set('asset_ezplatform_build_command', function() {
+   $composer = get('bin/composer');
+
+   return $composer . ' ezplatform-assets';
+});
 
 task('assets:deploy', [
     'assets:build',

--- a/deploy/tasks/assets.php
+++ b/deploy/tasks/assets.php
@@ -21,13 +21,13 @@ set('asset_ezplatform_build_command', function() {
    return $composer . ' ezplatform-assets';
 });
 
-task('assets:deploy', [
-    'assets:build',
-    'assets:ezplatform:build',
-    'assets:upload'
+task('app:assets:deploy', [
+    'app:assets:build',
+    'app:assets:ezplatform:build',
+    'app:assets:upload'
 ]);
 
-task('assets:build', function() {
+task('app:assets:build', function() {
     writeln('<comment>Checking for changes in asset files. If this fails, commit or stash your changes before deploying.</comment>');
     $assetResourcePaths = get('asset_resource_paths');
     foreach ($assetResourcePaths as $resourcePath) {
@@ -41,11 +41,11 @@ task('assets:build', function() {
     run($buildCmd);
 })->local();
 
-task('assets:ezplatform:build', function() {
+task('app:assets:ezplatform:build', function() {
     run("{{asset_ezplatform_build_command}}");
 })->local();
 
-task('assets:upload', function() {
+task('app:assets:upload', function() {
     $assetPaths = get('asset_build_paths');
     $excludedPaths = get('asset_exclude_paths', []);
 


### PR DESCRIPTION
This PR contains two somewhat related fixes:

1. 4df99cceb - seems that in https://github.com/netgen/media-site/pull/61 we forgot to activate the new task to build and deploy assets :) 
2. 266948d - there are cases where we need to redefine composer command, for example `set('bin/composer', 'php7.4 /usr/local/bin/composer2')` in case where there are both multiple versions of php and composer installed on server. This makes sure that `asset_ezplatform_build_command` configured composer instead of hardcoding just `composer` command.