### PR TITLE
NGSTACK-546 bugfix failing asset install and build

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "@babel/core": "^7.4.3",
         "@babel/preset-env": "^7.4.3",
         "@babel/preset-react": "^7.0.0",
-        "@symfony/webpack-encore": "^0.28.0",
+        "@symfony/webpack-encore": "^1.7.0",
         "autoprefixer": "^9.5.1",
         "eslint": "^8.3.0",
         "eslint-config-airbnb": "^19.0.2",
@@ -44,12 +44,12 @@
         "eslint-plugin-jsx-a11y": "^6.2.1",
         "eslint-plugin-react": "^7.12.4",
         "eslint-plugin-react-hooks": "^4.3.0",
-        "node-sass": "^4.11.0",
+        "node-sass": "^6.0.1",
         "path": "^0.12.7",
-        "postcss-loader": "^3.0.0",
+        "postcss-loader": "^6.2.1",
         "prettier": "^2.5.0",
         "sass-lint": "^1.12.1",
-        "sass-loader": "^7.1.0"
+        "sass-loader": "^12.3.0"
     },
     "dependencies": {
         "@babel/polyfill": "^7.4.3",

--- a/webpack.config.default.js
+++ b/webpack.config.default.js
@@ -24,8 +24,8 @@ Encore
 
   // allow sass/scss files to be processed
   .enableSassLoader((options) => {
-    options.includePaths = [path.resolve(__dirname, 'node_modules')]; // eslint-disable-line no-param-reassign
-    options.outputStyle = Encore.isProduction() ? 'compressed' : 'nested';
+    options.sassOptions.includePaths = [path.resolve(__dirname, 'node_modules')]; // eslint-disable-line no-param-reassign
+    options.sassOptions.outputStyle = Encore.isProduction() ? 'compressed' : 'nested';
   })
 
   // allow legacy applications to use $/jQuery as a global variable
@@ -40,30 +40,33 @@ Encore
   .enableVersioning(Encore.isProduction())
 
   .enablePostCssLoader((options) => {
-    options.config = { // eslint-disable-line no-param-reassign
-      path: 'postcss.config.js',
+    options.postcssOptions = {
+        path: 'postcss.config.js',
     };
   })
 
   .configureTerserPlugin((options) => {
-    options.cache = true;
     options.parallel = true;
     options.terserOptions = {
-      output: {
+      format: {
         comments: false,
       },
+      nameCache: {},
     };
   })
 
-  .enableSingleRuntimeChunk()
-;
+  .enableSingleRuntimeChunk();
 
 if (Encore.isProduction()) {
   Encore.configureFilenames({
     js: '[name].js?v=[contenthash]',
     css: '[name].css?v=[contenthash]',
-    images: 'images/[name].[ext]?v=[hash:8]',
-    fonts: 'fonts/[name].[ext]?v=[hash:8]',
+  });
+  Encore.configureImageRule({
+    filename: 'images/[name].[ext]?v=[hash:8]',
+  });
+  Encore.configureFontRule({
+    filename: 'fonts/[name].[ext]?v=[hash:8]',
   });
 }
 


### PR DESCRIPTION
Cause
- old dependencies do not work with Node 16, the latest LTS

Changes
- updated some sass-related dependencies so `yarn install` does not fail
- updated webpack encore package and config file to match the new version API so `yarn build:dev` and `yarn build:prod` would not fail

Testing
- for each Node version from 12, 14, and 16, run:
```bash
yarn install   
yarn build:dev
yarn build:prod
```
all commands should pass