### PR TITLE
NGSTACK-379: configure keep_request_method for no view redirect fallback

### DIFF
--- a/config/app/prepends/content_view.yaml
+++ b/config/app/prepends/content_view.yaml
@@ -47,7 +47,10 @@ frontend_group:
                         - ng_topic
                         - ng_video
             match_all:
-                permanent_redirect: '@=namedLocation("homepage")'
+                redirect:
+                    target: '@=namedLocation("homepage")'
+                    permanent: true
+                    keep_request_method: '%kernel.debug%'
                 match: ~
         line:
             common:


### PR DESCRIPTION
To go with:
- https://github.com/netgen/ibexa-site-api/pull/4

This configures the default no view redirect fallback with `keep_request_method` option se to `%kernel.debug%`.

This will produce `308` redirect in the debug mode, and `301` redirect otherwise (in production).