### PR TITLE
NGGW-82 Add command for clearing cache pool in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ ifeq ("$(wildcard $(COMPOSER_PATH))","")
 	COMPOSER_PATH = /usr/local/bin/composer
 endif
 COMPOSER_RUN = $(PHP_RUN) $(COMPOSER_PATH)
+CACHE_POOL = cache.redis
 
 .PHONY: help
 help: ## List of all available commands
@@ -51,6 +52,7 @@ assets-watch: ## Watch frontend assets (during development)
 .PHONY: clear-cache
 clear-cache: ## Clear caches for specified environment (default: SYMFONY_ENV=dev)
 	$(PHP_RUN) bin/console cache:clear --env=$(SYMFONY_ENV)
+	$(PHP_RUN) bin/console cache:pool:clear $(CACHE_POOL) --env=$(SYMFONY_ENV)
 
 .PHONY: images
 images: ## Generate most used image variations for all images for specified environment (default: SYMFONY_ENV=dev)

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ assets-watch: ## Watch frontend assets (during development)
 .PHONY: clear-cache
 clear-cache: ## Clear caches for specified environment (default: SYMFONY_ENV=dev)
 	$(PHP_RUN) bin/console cache:clear --env=$(SYMFONY_ENV)
+
+.PHONY: clear-all-cache
+clear-all-cache: ## Clear all caches for specified environment (including eg. Redis) (default: SYMFONY_ENV=dev)
+	@$(MAKE) -s clear-cache
 	$(PHP_RUN) bin/console cache:pool:clear $(CACHE_POOL) --env=$(SYMFONY_ENV)
 
 .PHONY: images


### PR DESCRIPTION
This PR adds command for clearing cache pool (default Redis) in Makefile, into existing `make clear-cache` command. Cache pool is configurable through variable in Makefile.