### PR TITLE
NGSTACK-605 quickfix for image wrapper

### DIFF
--- a/src/AppBundle/Resources/views/themes/common/parts/macros.html.twig
+++ b/src/AppBundle/Resources/views/themes/common/parts/macros.html.twig
@@ -31,7 +31,7 @@
     {% endif %}
     {% set lazy_loading = lazy_loading ?? ezpublish.configResolver.getParameter('lazy_loading.enabled', 'ngsite') %}
 
-    {% if url is not empty %}
+    {% if url is empty %}
         <span>
     {% endif %}
     {{ ng_render_field(
@@ -44,7 +44,7 @@
             }
         }
     ) }}
-    {% if url is not empty %}
+    {% if url is empty %}
         </span>
     {% endif %}
     


### PR DESCRIPTION
Fix issue where image without link would be without wrapper, which made markup insufficient for styling. 