### PR TITLE
NGSTACK-746: fix opengraph image alias

### DIFF
--- a/config/app/packages/opengraph.yaml
+++ b/config/app/packages/opengraph.yaml
@@ -21,17 +21,17 @@ netgen_open_graph:
                     - { handler: literal/text, tag: "og:type", params: [article] }
                     - { handler: field_type/ezstring, tag: "og:title", params: [title] }
                     - { handler: field_type/ezrichtext, tag: "og:description", params: [full_intro] }
-                    - { handler: field_type/ezimage, tag: "og:image", params: [image, i1200] }
+                    - { handler: field_type/ezimage, tag: "og:image", params: [image, i1320] }
                 ng_news:
                     - { handler: literal/text, tag: "og:type", params: [article] }
                     - { handler: field_type/ezstring, tag: "og:title", params: [title] }
                     - { handler: field_type/ezrichtext, tag: "og:description", params: [full_intro] }
-                    - { handler: field_type/ezimage, tag: "og:image", params: [image, i1200] }
+                    - { handler: field_type/ezimage, tag: "og:image", params: [image, i1320] }
                 ng_blog_post:
                     - { handler: literal/text, tag: "og:type", params: [article] }
                     - { handler: field_type/ezstring, tag: "og:title", params: [title] }
                     - { handler: field_type/ezrichtext, tag: "og:description", params: [full_intro] }
-                    - { handler: field_type/ezimage, tag: "og:image", params: [image, i1200] }
+                    - { handler: field_type/ezimage, tag: "og:image", params: [image, i1320] }
                 ng_contact_form:
                     - { handler: literal/text, tag: "og:type", params: [article] }
                     - { handler: field_type/ezstring, tag: "og:title", params: [title] }


### PR DESCRIPTION
Image alias `i1200` was removed in https://github.com/netgen/media-site/commit/0f921481961a597263f16fc096ebee8e44ea8d2a.