### PR TITLE
NGGW-105 fix assets build so it does not use sub-make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,20 +32,17 @@ assets-node:
 	. ${NVM_DIR}/nvm.sh && nvm use || nvm install $(cat .nvmrc)
 
 .PHONY: assets
-assets: ## Build frontend assets for DEV environment
-	@$(MAKE) -s assets-node
+assets: assets-node ## Build frontend assets for DEV environment
 	yarn install
 	yarn build:dev
 
 .PHONY: assets-prod
-assets-prod: ## Build frontend assets for PROD environment
-	@$(MAKE) -s assets-node
+assets-prod: assets-node ## Build frontend assets for PROD environment
 	yarn install
 	yarn build:prod
 
 .PHONY: assets-watch
-assets-watch: ## Watch frontend assets (during development)
-	@$(MAKE) -s assets-node
+assets-watch: assets-node ## Watch frontend assets (during development)
 	yarn install
 	yarn watch
 

--- a/Makefile
+++ b/Makefile
@@ -27,22 +27,24 @@ endif
 vendor: ## Run composer install
 	$(COMPOSER_RUN) install $(COMPOSER_INSTALL_PARAMETERS)
 
-.PHONY: assets-node
-assets-node:
-	. ${NVM_DIR}/nvm.sh && nvm use || nvm install $(cat .nvmrc)
-
 .PHONY: assets
-assets: assets-node ## Build frontend assets for DEV environment
+.ONESHELL:
+assets: ## Build frontend assets for DEV environment
+	. ${NVM_DIR}/nvm.sh && nvm use || nvm install $(cat .nvmrc)
 	yarn install
 	yarn build:dev
 
 .PHONY: assets-prod
+.ONESHELL:
 assets-prod: assets-node ## Build frontend assets for PROD environment
+	. ${NVM_DIR}/nvm.sh && nvm use || nvm install $(cat .nvmrc)
 	yarn install
 	yarn build:prod
 
 .PHONY: assets-watch
+.ONESHELL:
 assets-watch: assets-node ## Watch frontend assets (during development)
+	. ${NVM_DIR}/nvm.sh && nvm use || nvm install $(cat .nvmrc)
 	yarn install
 	yarn watch
 

--- a/Makefile
+++ b/Makefile
@@ -36,14 +36,14 @@ assets: ## Build frontend assets for DEV environment
 
 .PHONY: assets-prod
 .ONESHELL:
-assets-prod: assets-node ## Build frontend assets for PROD environment
+assets-prod: ## Build frontend assets for PROD environment
 	. ${NVM_DIR}/nvm.sh && nvm use || nvm install $(cat .nvmrc)
 	yarn install
 	yarn build:prod
 
 .PHONY: assets-watch
 .ONESHELL:
-assets-watch: assets-node ## Watch frontend assets (during development)
+assets-watch: ## Watch frontend assets (during development)
 	. ${NVM_DIR}/nvm.sh && nvm use || nvm install $(cat .nvmrc)
 	yarn install
 	yarn watch


### PR DESCRIPTION
As it turns out, each line in the recipe is run in a separate shell :open_mouth: 
`.ONESHELL` directive makes the whole recipe run in a single shell, therefore keeping the node version between the commands.