### PR TITLE
Add PHPStan baseline to exclude most frequent errors related to Ibexa

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,4 @@
+parameters:
+    ignoreErrors:
+        - '#Access to an undefined property Ibexa\\Contracts\\Core\\FieldType\\Value::\$\w+#'
+        - '#Cannot access property \$\w+ on Ibexa\\Contracts\\Core\\FieldType\\Value\|null#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,11 @@
+includes:
+	- phpstan-baseline.neon
+
 parameters:
+    reportUnmatchedIgnoredErrors: false
+
     excludePaths:
        - src/Kernel.php
+
     symfony:
         container_xml_path: var/cache/dev/App_KernelDevDebugContainer.xml
-


### PR DESCRIPTION
This adds some useful PHPStan ignore rules which are related to how Ibexa handles content fields and their values, e.g.

```php
$content->getFieldValue('title')->text
```

would result in an error:

```
Access to an undefined property Ibexa\Contracts\Core\FieldType\Value::$text
```

I will add more later as I run into them