### PR TITLE
add missing parameter used in novactive_ez_seo.yaml

### DIFF
--- a/config/app/server/dev/app.yaml
+++ b/config/app/server/dev/app.yaml
@@ -1,4 +1,5 @@
 parameters:
+    ngsite.default.site_domain: localhost
     ngsite.fh_group.site_domain: localhost
     ngsite.bold_group.site_domain: localhost
 


### PR DESCRIPTION
![Screenshot from 2023-05-25 14-15-48](https://github.com/netgen/media-site/assets/56323188/04ff7c28-15f9-47d8-86ed-8cb2324f1c8d)
I added missing parameter that caused error when i tried to locally install new media-site instance. It is used in config/packages/novactive_ez_seo.yaml. 
