### PR TITLE
Fix site title override from content metadata field

### DIFF
--- a/templates/themes/app/pagelayout/head/title.html.twig
+++ b/templates/themes/app/pagelayout/head/title.html.twig
@@ -15,14 +15,20 @@
         {% endif %}
     {% endif %}
 
+    {% if content is defined %}
+        {% if content.hasField('metadata') and not content.fields.metadata.empty %}
+            {% set content_meta_data = content.fields.metadata.value %}
+
+            {% if content_meta_data.metas['title'].content|default('') is not empty %}
+                {% set site_title = content_meta_data.metas['title'].content %}
+            {% endif %}
+        {% endif %}
+    {% endif %}
+
     {% if site_title is not empty %}
         {% set site_title = site_title ~ (site_name is not empty ? ' - ' ~ site_name : '') %}
     {% else %}
         {% set site_title = site_name|default('') %}
-    {% endif %}
-
-    {% if content_meta_data.title|default('') is not empty %}
-        {% set site_title = content_meta_data.title %}
     {% endif %}
 {% endapply %}
 


### PR DESCRIPTION
This PR fixes the following issues:

1. It was impossible to set site meta title from the content metadata field. content_meta_data object is being set in another template (meta.html.twig) which is included after the title.html.twig. The logic for the title and other meta tags is now properly separated.
2. When the site_title was taken from the content metadata field, it would be outputted without the dash character + site_name suffix. This is not correct, as the site name is appended to site title if the site title comes from any other source (default generated from path, or site_title being set in the full view template). The content metadata field logic is now moved right before the title tag output, as it is a top-priority override, and it get proper site name suffix