### PR TITLE
NGSTACK-779 eslint

### DIFF
--- a/assets/js/components/CookieControl.component.js
+++ b/assets/js/components/CookieControl.component.js
@@ -13,12 +13,12 @@ export default class CookieControl {
   }
 
   init() {
-    this.initNetgenCookieControl();
+    CookieControl.initNetgenCookieControl();
     this.optionalListToggle.addEventListener('click', this.handleOptionalListToggle.bind(this));
-    this.optionalSaveBtn.addEventListener('click', this.handleConsentChange);
+    this.optionalSaveBtn.addEventListener('click', CookieControl.handleConsentChange);
   }
 
-  initNetgenCookieControl() {
+  static initNetgenCookieControl() {
     // eslint-disable-next-line no-underscore-dangle
     const cookieControl = new NetgenCookieControl(window.__ngCcConfig);
     cookieControl.init();
@@ -35,7 +35,7 @@ export default class CookieControl {
     this.optionalListToggle.classList.toggle(this.options.shownClass);
   }
 
-  handleConsentChange(event) {
+  static handleConsentChange(event) {
     event.preventDefault();
 
     GTM.push('ngcc', GTM.EVENTS.CHANGED);

--- a/assets/js/components/GalleryBlock.component.js
+++ b/assets/js/components/GalleryBlock.component.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
 import PhotoSwipeLightbox from 'photoswipe/lightbox';
 
 export default class GalleryBlock {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
         "site:watch": "encore dev --watch --config-name",
         "site:server": "encore dev-server --config-name",
         "ibexa": "encore production --config=webpack.config.ibexa.js",
-        "format:js": "prettier --write assets/js/*"
+        "format:js": "prettier --write assets/js/**/*.js",
+        "linter:js": "eslint --fix assets/js/**/*.js"
     },
     "private": true,
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
         "site:watch": "encore dev --watch --config-name",
         "site:server": "encore dev-server --config-name",
         "ibexa": "encore production --config=webpack.config.ibexa.js",
-        "format:js": "prettier --write assets/js/**/*.js",
-        "linter:js": "eslint --fix assets/js/**/*.js"
+        "format:js": "prettier --write \"assets/js/**/*.js\"",
+        "linter:js": "eslint --fix \"assets/js/**/*.js\""
     },
     "private": true,
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "site:server": "encore dev-server --config-name",
         "ibexa": "encore production --config=webpack.config.ibexa.js",
         "format:js": "prettier --write \"assets/js/**/*.js\"",
-        "linter:js": "eslint --fix \"assets/js/**/*.js\""
+        "linter:js": "eslint \"assets/js/**/*.js\""
     },
     "private": true,
     "devDependencies": {


### PR DESCRIPTION
- fixed "this" eslint error by using static methods
- fixed "unresolved import" by disabling eslint for that line
    - not sure why it cannot resolve this import since the way it's defined in the package works and is supported by the webpack version used in the project, obviously
    - eslint also supposedly supports this kind of package export with the import plugin, but it's pretty updated and even the most recent update didn't help
    - https://webpack.js.org/guides/package-exports/
- added linter:js yarn script, fixed path with globs for eslint and prettier