### PR TITLE
NGSTACK-788 add max score zero check before division

### DIFF
--- a/templates/themes/app/pages/search.html.twig
+++ b/templates/themes/app/pages/search.html.twig
@@ -49,7 +49,7 @@
                                 <div id="search-result" class="search-result">
                                     {% for search_hit in pager.currentPageResults.searchHits %}
                                         {% set score = null %}
-                                        {% if search_hit.score is not null and pager.adapter.maxScore is defined and pager.adapter.maxScore is not null %}
+                                        {% if search_hit.score is not null and pager.adapter.maxScore is defined and pager.adapter.maxScore is not null and pager.adapter.maxScore != 0 %}
                                             {% set score = (search_hit.score / pager.adapter.maxScore * 100)|round %}
                                         {% endif %}
 


### PR DESCRIPTION
https://netgen.atlassian.net/browse/NGSTACK-788
I added zero check for maxScore to prevent division by zero error.
This is because maxScore can now be 0 https://github.com/netgen/ibexa-search-extra/pull/3