### PR TITLE
Bump ngenhancedlink

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "netgen/ibexa-site-api": "^5.1",
         "netgen/ibexa-search-extra": "^3.0",
         "netgen/information-collection-bundle": "^3.0@alpha",
-        "netgen/ibexa-fieldtype-enhanced-link": "^1.0",
+        "netgen/ibexa-fieldtype-enhanced-link": "^1.1",
         "netgen/better-ibexa-admin-ui": "^1.0",
 
         "netgen/layouts-standard": "~1.4.0",

--- a/templates/themes/app/content/parts/content_fields.html.twig
+++ b/templates/themes/app/content/parts/content_fields.html.twig
@@ -7,8 +7,9 @@
     {% if not ibexa_field_is_empty(content, field) %}
         {% set css_class = parameters.css_class|default('') %}
         <div {{ block('field_attributes') }}>
+            {% dump %}
             {% if field.value.isTypeInternal %}
-                {% set label = field.value.label ? field.value.label : ngsite_content_name(field.value.reference) %}
+                {% set label = fieldSettings.enableLabelInternal and field.value.label ? field.value.label : ngsite_content_name(field.value.reference) %}
                 {% set suffix = field.value.suffix|default('') %}
                 {% if field.value.isTargetModal %}
                     {{ ng_view_content_embedded(
@@ -42,7 +43,7 @@
                     {% endif %}
                 {% endif %}
             {% elseif field.value.isTypeExternal %}
-                {% set label = field.value.label ? field.value.label : field.value.reference %}
+                {% set label = fieldSettings.enableLabelExternal and field.value.label ? field.value.label : field.value.reference %}
 
                 {% if field.value.isTargetModal %}
                     <div>{{ label }}</div>


### PR DESCRIPTION
`ngenhancedlink` in `1.1` added enabling/disabling link labels in the field definition. This updates the field type template and `ngenhancedlink` version.