### PR TITLE
Update error templates with correct button link to homepage

### DIFF
--- a/templates/themes/app/errors/403.html.twig
+++ b/templates/themes/app/errors/403.html.twig
@@ -11,9 +11,9 @@
             <p class="site-error-message">{{ 'ngsite.errors.403.message'|trans }}</p>
         </div>
         <div class="site-error-buttons text-center">
-            <button class="btn btn-primary">
-                {{ 'ngsite.errors.button.back'|trans }}
-            </button>
+            <div class="site-error-buttons text-center">
+                <a href="{{ ibexa_path(ibexa.rootLocation) }}" class="btn btn-primary">{{ 'ngsite.errors.button.back'|trans }}</a>
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/templates/themes/app/errors/404.html.twig
+++ b/templates/themes/app/errors/404.html.twig
@@ -11,9 +11,7 @@
             <p class="site-error-message">{{ 'ngsite.errors.404.message'|trans }}</p>
         </div>
         <div class="site-error-buttons text-center">
-            <button class="btn btn-primary">
-                {{ 'ngsite.errors.button.back'|trans }}
-            </button>
+            <a href="{{ ibexa_path(ibexa.rootLocation) }}" class="btn btn-primary">{{ 'ngsite.errors.button.back'|trans }}</a>
         </div>
     </div>
 {% endblock %}

--- a/templates/themes/app/errors/410.html.twig
+++ b/templates/themes/app/errors/410.html.twig
@@ -11,9 +11,7 @@
             <p class="site-error-message">{{ 'ngsite.errors.410.message'|trans }}</p>
         </div>
         <div class="site-error-buttons text-center">
-            <button class="btn btn-primary">
-                {{ 'ngsite.errors.button.back'|trans }}
-            </button>
+            <a href="{{ ibexa_path(ibexa.rootLocation) }}" class="btn btn-primary">{{ 'ngsite.errors.button.back'|trans }}</a>
         </div>
     </div>
 {% endblock %}

--- a/templates/themes/app/errors/500.html.twig
+++ b/templates/themes/app/errors/500.html.twig
@@ -11,9 +11,7 @@
             <p class="site-error-message">{{ 'ngsite.errors.500.message'|trans }}</p>
         </div>
         <div class="site-error-buttons text-center">
-            <button class="btn btn-primary">
-                {{ 'ngsite.errors.button.back'|trans }}
-            </button>
+            <a href="{{ ibexa_path(ibexa.rootLocation) }}" class="btn btn-primary">{{ 'ngsite.errors.button.back'|trans }}</a>
         </div>
     </div>
 {% endblock %}

--- a/templates/themes/app/errors/default.html.twig
+++ b/templates/themes/app/errors/default.html.twig
@@ -11,9 +11,7 @@
             <p class="site-error-message">{{ 'ngsite.errors.default.message'|trans }}</p>
         </div>
         <div class="site-error-buttons text-center">
-            <button class="btn btn-primary">
-                {{ 'ngsite.errors.button.back'|trans }}
-            </button>
+            <a href="{{ ibexa_path(ibexa.rootLocation) }}" class="btn btn-primary">{{ 'ngsite.errors.button.back'|trans }}</a>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
At the moment empty buttons are added in templates which serve no purpose. This fix will provide a proper markup for actually making buttons clickable and will return the user to proper homepage.