### PR TITLE
NGSTACK-1 fix broken JS in cookie ribbon

### DIFF
--- a/templates/themes/app/pagelayout/cookie_control.html.twig
+++ b/templates/themes/app/pagelayout/cookie_control.html.twig
@@ -122,6 +122,7 @@
                   {% if not cookie_policy.fields.social_sharing_on_revoke.empty %}
                   {{ cookie_policy.fields.social_sharing_on_revoke.value|raw }}
                   {% endif %}
+                },
               },
               {% endif %}
             ],


### PR DESCRIPTION
Social sharing cookies JS component had a syntax error where onRevoke function wasn't closed.