### PR TITLE
Fix duplicated wrapper issue on error page

### DIFF
--- a/templates/themes/app/errors/403.html.twig
+++ b/templates/themes/app/errors/403.html.twig
@@ -11,9 +11,7 @@
             <p class="site-error-message">{{ 'ngsite.errors.403.message'|trans }}</p>
         </div>
         <div class="site-error-buttons text-center">
-            <div class="site-error-buttons text-center">
-                <a href="{{ ibexa_path(ibexa.rootLocation) }}" class="btn btn-primary">{{ 'ngsite.errors.button.back'|trans }}</a>
-            </div>
+            <a href="{{ ibexa_path(ibexa.rootLocation) }}" class="btn btn-primary">{{ 'ngsite.errors.button.back'|trans }}</a>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
This issue was generated by my carelessness. All error pages will now have unified markup.