### PR TITLE
NGSTACK-901 Webp support

### DIFF
--- a/src/AppBundle/Resources/config/image.yml
+++ b/src/AppBundle/Resources/config/image.yml
@@ -57,10 +57,15 @@ ezpublish:
                         - { name: strip }
 
 liip_imagine:
+    # global setting, all filters will generate webp images
+    default_filter_set_settings:
+        format: webp
     filter_sets:
         small:
             quality: 85
             jpeg_quality: 85
+            # format can also be defined per filter
+            #format: webp
         medium:
             quality: 85
             jpeg_quality: 85

--- a/src/AppBundle/ezpublish_legacy/app/settings/image.ini.append.php
+++ b/src/AppBundle/ezpublish_legacy/app/settings/image.ini.append.php
@@ -9,4 +9,27 @@ PreParameters=+profile "*"
 [MIMETypeSettings]
 Quality[]
 Quality[]=image/jpeg;90
+Quality[]=image/webp;90
+
+# The global conversion rules
+# Most will be converted to jpeg except gif and xpms
+ConversionRules[]
+ConversionRules[]=image/gif;image/png
+ConversionRules[]=image/x-xpixmap;image/png
+ConversionRules[]=image/webp;image/webp
+# force aliases from jpeg originals to be generated as webp
+ConversionRules[]=image/jpeg;image/webp
+# force aliases from originals in any non-specified format to be generated as webp
+#ConversionRules[]=*;image/webp
+ConversionRules[]=*;image/jpeg
+
+[OutputSettings]
+# A list of MIME types that are allowed as output type
+# This determines which formats you want your web page to display
+AllowedOutputFormat[]=image/webp
+
+[ImageMagick]
+QualityParameters[]=image/webp;-quality %1
+MIMETagMap[]=image/webp;WEBP
+
 */ ?>

--- a/src/AppBundle/ezpublish_legacy/app/settings/mime.ini.append.php
+++ b/src/AppBundle/ezpublish_legacy/app/settings/mime.ini.append.php
@@ -1,0 +1,6 @@
+<?php /* #?ini charset="utf-8"?
+
+[webp]
+Types[]=image/webp
+
+*/ ?>

--- a/src/AppBundle/ezpublish_legacy/app/settings/siteaccess/ngadminui/image.ini.append.php
+++ b/src/AppBundle/ezpublish_legacy/app/settings/siteaccess/ngadminui/image.ini.append.php
@@ -8,16 +8,20 @@ AliasList[]=large
 
 [small]
 Reference=original
+# you can disable global ConversionRules for webp, and specify target mime type for each alias
+#MIMEType=image/webp
 Filters[]
 Filters[]=geometry/scaledownonly=100;100
 
 [medium]
 Reference=original
+#MIMEType=image/webp
 Filters[]
 Filters[]=geometry/scaledownonly=200;200
 
 [large]
 Reference=original
+#MIMEType=image/webp
 Filters[]
 Filters[]=geometry/scaledownonly=300;300
 */ ?>


### PR DESCRIPTION
Requires https://github.com/netgen/site-bundle/pull/51 to be reviewed and merged first.

This PR enables WebP support for legacy kernel/admin UI, and sets all image aliases generated in legacy kernel or through LiipImagine bundle to be converted, stored and outputted in WebP format.

This feature requires Imagemagick with libwebp delegate library included.

