### PR TITLE
NGSTACK-915 - google consent v2

### DIFF
--- a/assets/js/components/CookieControl.component.js
+++ b/assets/js/components/CookieControl.component.js
@@ -16,7 +16,7 @@ export default class CookieControl {
     CookieControl.initNetgenCookieControl();
     this.optionalListToggle.addEventListener('click', this.handleOptionalListToggle.bind(this));
     this.optionalSaveBtn.forEach((element) =>
-      element.addEventListener('click', this.handleConsentChange)
+      element.addEventListener('click', CookieControl.handleConsentChange)
     );
   }
 
@@ -41,5 +41,35 @@ export default class CookieControl {
     event.preventDefault();
 
     GTM.push('ngcc', GTM.EVENTS.CHANGED);
+
+    // check if analytics and marketing cookie status changed and update consents
+    if (typeof window.getCookieStatus === 'function') {
+      const analyticsStatus = window.getCookieStatus('ng-cc-analytics');
+      if (window.lastAnalyticsStatus !== analyticsStatus) {
+        window.gtag('consent', 'update', {
+          ad_storage: analyticsStatus,
+          analytics_storage: analyticsStatus,
+        });
+        window.lastAnalyticsStatus = analyticsStatus;
+        const bcolor = analyticsStatus === 'granted' ? 'green' : 'orange';
+        console.info(
+          '%cAnalytics cookie changed to: ' + analyticsStatus,
+          'color: white; background-color: ' + bcolor
+        );
+      }
+      const marketingStatus = window.getCookieStatus('ng-cc-marketing');
+      if (window.lastMarketingStatus !== marketingStatus) {
+        window.gtag('consent', 'update', {
+          ad_user_data: marketingStatus,
+          ad_personalization: marketingStatus,
+        });
+        window.lastMarketingStatus = marketingStatus;
+        const bcolor = marketingStatus === 'granted' ? 'green' : 'orange';
+        console.info(
+          '%cMarketing cookie changed to: ' + marketingStatus,
+          'color: white; background-color: ' + bcolor
+        );
+      }
+    }
   }
 }

--- a/templates/themes/app/parts/google_tag_manager_code_script.html.twig
+++ b/templates/themes/app/parts/google_tag_manager_code_script.html.twig
@@ -2,10 +2,38 @@
     {% set google_tag_manager_code = ibexa.configResolver.getParameter('site_settings.google_tag_manager_code', 'ngsite') %}
 
     {% if google_tag_manager_code is not empty %}
+
+        <script>
+            // DataLayer and the gtag function.
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+
+            // Get denied or granted from cookie
+            window.getCookieStatus = function(cookieName) {
+                var cookieValue = document.cookie.replace(new RegExp("(?:(?:^|.*;\\s*)" + cookieName + "\\s*=\\s*([^;]*).*$)|^.*$"), "$1");
+                return cookieValue === undefined ? 'denied' : cookieValue === '1' ? 'granted' : 'denied';
+            }
+
+            // Set global status for dynamic handling
+            window.lastAnalyticsStatus = getCookieStatus('ng-cc-analytics');
+            window.lastMarketingStatus = getCookieStatus('ng-cc-marketing');
+
+            // Set default consent based on cookie status
+            gtag('consent', 'default', {
+                'ad_storage': getCookieStatus('ng-cc-marketing'),
+                'ad_user_data': getCookieStatus('ng-cc-marketing'),
+                'ad_personalization': getCookieStatus('ng-cc-marketing'),
+                'analytics_storage': getCookieStatus('ng-cc-analytics')
+            });
+        </script>
+
+        <!-- Google Tag Manager -->
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','{{ google_tag_manager_code|raw|escape('js') }}');</script>
+        <!-- End Google Tag Manager -->
+
     {% endif %}
 {% endif %}


### PR DESCRIPTION
Added new logic for google consent. 

- main part is in the google_tag_manager_code_script.html.twig
- enhancing part is in the CookieControl.component.js

- small older bug fixed in the CookieControl.component.js  line 19
