### PR TITLE
NGSTACK-925 Downgrade phpdoc-parser version beacuse of serializer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,8 @@
         "phpunit/phpunit": "^9.5",
         "symfony/browser-kit": "5.4.*",
         "symfony/css-selector": "5.4.*",
-        "symfony/phpunit-bridge": "5.4.*"
+        "symfony/phpunit-bridge": "5.4.*",
+        "phpstan/phpdoc-parser": "^1.33"
     },
     "repositories": [
         { "type": "vcs", "url": "https://github.com/netgen/NovaeZSEOBundle.git" }

--- a/composer.json
+++ b/composer.json
@@ -73,8 +73,7 @@
         "phpunit/phpunit": "^9.5",
         "symfony/browser-kit": "5.4.*",
         "symfony/css-selector": "5.4.*",
-        "symfony/phpunit-bridge": "5.4.*",
-        "phpstan/phpdoc-parser": "^1.33"
+        "symfony/phpunit-bridge": "5.4.*"
     },
     "repositories": [
         { "type": "vcs", "url": "https://github.com/netgen/NovaeZSEOBundle.git" }
@@ -133,7 +132,8 @@
     },
     "conflict": {
         "symfony/symfony": "*",
-        "ibexa/core": "<4.6.10"
+        "ibexa/core": "<4.6.10",
+        "phpstan/phpdoc-parser": ">=2.0"
     },
     "extra": {
         "symfony": {


### PR DESCRIPTION
symfony/serializer-pack v1.3.0 package requires "phpstan/phpdoc-parser": "*":
phpdoc-parser got released with version 2.0 so we need to lock it to 1.33 to avoid exception:

CRITICAL [php] Uncaught Error: Too few arguments to function PHPStan\PhpDocParser\Parser\ConstExprParser::__construct(), 0 passed in /home/iherak/temp/media-site/vendor/symfony/property-info/Extractor/PhpStanExtractor.php on line 76 and exactly 1 expected ["exception" => ArgumentCountError { …}]

