### PR TITLE
Do not show cookie settings button if there is no related cookie policy

### DIFF
--- a/templates/themes/app/pagelayout/cookie_control.html.twig
+++ b/templates/themes/app/pagelayout/cookie_control.html.twig
@@ -1,4 +1,4 @@
-{% if ngsite.siteInfoContent.hasField('related_cookie_policy') and not ngsite.siteInfoContent.fields.related_cookie_policy.empty %}
+{% if not ngsite.siteInfoContent.fields.related_cookie_policy.empty %}
     {% set cookie_policy = ngsite.siteInfoContent.fieldRelation('related_cookie_policy') %}
 
     <div id="ng-cc">

--- a/templates/themes/app/pagelayout/footer.html.twig
+++ b/templates/themes/app/pagelayout/footer.html.twig
@@ -57,7 +57,7 @@
         </div>
 
         <div class="footer-info">
-            {% if ngsite.siteInfoContent.hasField('related_cookie_policy') and not ngsite.siteInfoContent.fields.related_cookie_policy.empty %}
+            {% if not ngsite.siteInfoContent.fields.related_cookie_policy.empty %}
                 <a href="#" class="js-open-ng-cc d-block my-2">{{ 'ngsite.layout.cookie_settings'|trans }}</a>
             {% endif %}
 

--- a/templates/themes/app/pagelayout/footer.html.twig
+++ b/templates/themes/app/pagelayout/footer.html.twig
@@ -57,7 +57,10 @@
         </div>
 
         <div class="footer-info">
-            <a href="#" class="js-open-ng-cc d-block my-2">{{ 'ngsite.layout.cookie_settings'|trans }}</a>
+            {% if ngsite.siteInfoContent.hasField('related_cookie_policy') and not ngsite.siteInfoContent.fields.related_cookie_policy.empty %}
+                <a href="#" class="js-open-ng-cc d-block my-2">{{ 'ngsite.layout.cookie_settings'|trans }}</a>
+            {% endif %}
+
             {% if not site_info.fields.footer_block.empty %}
                 <div>
                     {{ ng_render_field(site_info.fields.footer_block) }}


### PR DESCRIPTION
There are situations where we have third party cookie policy and with that it's own cookie settings. In that case we do not want to show our cookie settings button.