### PR TITLE
NGSTACK-955 generate graphql on remote during deploy

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -55,10 +55,11 @@ task('deploy', [
     'deploy:shared',
     // build and upload assets
     'app:assets:deploy',
-    'app:graphql:deploy',
     // copy vendors folder between releases before running composer install to speed it up
     'deploy:copy_dirs',
     'deploy:vendors',
+    // build admin schema
+    'app:graphql:deploy',
     //'deploy:assets:install',
     'deploy:sentry:symfony',
     'deploy:sentry',

--- a/deploy/tasks/graphql.php
+++ b/deploy/tasks/graphql.php
@@ -2,18 +2,12 @@
 
 namespace Deployer;
 
-set('graphql_generate_command', '{{local_php_path}} bin/console ibexa:graphql:generate-schema');
+set('graphql_generate_command', '{{bin/php}} {{bin/console}} ibexa:graphql:generate-schema');
 
 task('app:graphql:deploy', [
     'app:graphql:generate',
-    'app:graphql:upload'
 ]);
 
 task('app:graphql:generate', function () {
     run("{{graphql_generate_command}}");
-})->local();
-
-
-task('app:graphql:upload', function () {
-    upload("config/graphql", "{{release_path}}/config");
 });


### PR DESCRIPTION
Changes
---
- removed local running of graphql schema generation
- removed upload of local graphql files
- using remote php and console paths in command
- moved task after vendor deploy since vendor is needed to be able to run the console command
Testing
---
- deploying a project without a local database works
- with verbose output it should be visible that the command is run on the remote with correct php and console paths