### PR TITLE
Exclude unwanted logs in error reporting

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -14,7 +14,14 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
+use function error_reporting;
 use function preg_match;
+
+use const E_ALL;
+use const E_DEPRECATED;
+use const E_NOTICE;
+use const E_STRICT;
+use const E_USER_DEPRECATED;
 
 final class Kernel extends BaseKernel
 {
@@ -28,6 +35,16 @@ final class Kernel extends BaseKernel
     {
         $container->addCompilerPass(new CompilerPass\XslRegisterPass());
     }
+
+    public function boot()
+    {
+        parent::boot();
+
+        if ($this->environment === 'prod') {
+            error_reporting(E_ALL & ~E_DEPRECATED & ~E_NOTICE & ~E_STRICT & ~E_USER_DEPRECATED);
+        }
+    }
+
 
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {


### PR DESCRIPTION
Symfony has a problem with overriding error reporting levels that can not be fixed by configuration in yaml.

There are 2 issuses opened, but nothing has been done regarding this:
https://github.com/symfony/symfony-docs/issues/17592
https://github.com/symfony/symfony/issues/35575
