### PR TITLE
NGSTACK-978 add more null checks, change selector that inits component

### DIFF
--- a/assets/js/components-noncritical.js
+++ b/assets/js/components-noncritical.js
@@ -64,7 +64,7 @@ const componentConfiguration = [
   },
   {
     Component: PageHeader,
-    selector: 'html',
+    selector: '.site-header',
     options: {
       pageWrapper: 'html',
       navToggle: '.mainnav-toggle',

--- a/assets/js/components/PageHeader.component.js
+++ b/assets/js/components/PageHeader.component.js
@@ -141,7 +141,7 @@ export default class PageHeader {
     const activeItemsList = JSON.parse(page.dataset.path);
     const navigationList = document.querySelectorAll(this.options.navigationList);
 
-    navigationList?.forEach((navigation) => {
+    navigationList.forEach((navigation) => {
       activeItemsList.forEach((activeItemId) => {
         const item = navigation.querySelector(`[data-location-id="${activeItemId}"]`);
 

--- a/assets/js/components/PageHeader.component.js
+++ b/assets/js/components/PageHeader.component.js
@@ -8,7 +8,7 @@ export default class PageHeader {
     this.navToggle = document.querySelector(options.navToggle);
     this.searchToggle = document.querySelector(options.searchToggle);
     this.headerSearch = document.querySelector(options.headerSearch);
-    this.searchInput = this.headerSearch.querySelector(options.searchInput);
+    this.searchInput = this.headerSearch?.querySelector(options.searchInput) ?? null;
     this.mainNav = document.querySelector(options.mainNav);
     this.level1Menus = [];
     this.submenuTriggerElements = [];
@@ -70,7 +70,7 @@ export default class PageHeader {
 
       const ariaExpanded = this.searchToggle.getAttribute('aria-expanded') === 'true';
       this.searchToggle.setAttribute('aria-expanded', !ariaExpanded);
-      this.searchInput.focus();
+      this.searchInput?.focus();
     });
   }
 
@@ -141,7 +141,7 @@ export default class PageHeader {
     const activeItemsList = JSON.parse(page.dataset.path);
     const navigationList = document.querySelectorAll(this.options.navigationList);
 
-    navigationList.forEach((navigation) => {
+    navigationList?.forEach((navigation) => {
       activeItemsList.forEach((activeItemId) => {
         const item = navigation.querySelector(`[data-location-id="${activeItemId}"]`);
 


### PR DESCRIPTION
- changed main selector to .site-header instead of html, so it only tries to initialise the component when site-header is present instead of always. I am not sure why "html" was used before, but this should work as well from what I've noticed (everything used in the component seems to be inside the header anyway, though it is not used for DOM queries)
- added nullish query selector to headerSearch because that component can be null, fallback to null instead of default undefined
- added nullish call to focus on input because idk if it can not exist in case the toggle exists, might be unnecessary

The rest seems fine as it already has null checks in init functions for important elements.

Testing should be done with whole or partial removal of header parts according to real use cases for removing parts.