### PR TITLE
NGSTACK-1011 Improve and simplify accessibility highlighting

### DIFF
--- a/assets/sass/_accessibility.scss
+++ b/assets/sass/_accessibility.scss
@@ -1,16 +1,16 @@
 @mixin highlight {
     outline: none;
-    background-color: $primary!important;
-    color: $black !important;
+    background-color: $primary !important;
+    color: color-contrast($primary) !important;
     .bg-color-primary & {
-        background-color: $black!important;
+        background-color: color-contrast($primary) !important;
         color: $primary !important;
     }
 }
 
-@mixin custom-outline($border-color: $primary, $accent-color: $outline-color) {
+@mixin custom-outline {
     outline: 2px transparent solid;
-    box-shadow: 0 0 0 2px $accent-color, 0 0 0 4px $border-color, 0 0 4px 8px $accent-color;
+    box-shadow: 0 0 0 2px $white, 0 0 0 4px $black;
 }
 
 #skip-to-main-content,

--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -19,7 +19,6 @@ $gray-38: hsl(0, 0, 62);
 $gray-19: hsl(0, 0, 81);
 $gray-12: hsl(0, 0, 88);
 $gray-7: hsl(0, 0, 93);
-$outline-color: #4D90FE;
 
 $body-bg: $white;
 $footer-bg: $black;


### PR DESCRIPTION
Adjusting `highlight` function:
-  using `color-contrast()` function to set dynamically white or black color based on the primary color (or whatever `$color-contrast-dark` and `$color-contrast-light` are set to)

Adjusting `custom-outline` function:
- simplifying the styles using only black and white colors, which work in every color scheme
- removing `$outline-color` from variables since it's not in use anymore