### PR TITLE
NGSTACK-1015 Improve navigation accessibility and UX

### DIFF
--- a/assets/js/components-noncritical.js
+++ b/assets/js/components-noncritical.js
@@ -66,23 +66,31 @@ const componentConfiguration = [
     Component: PageHeader,
     selector: '.site-header',
     options: {
+      // Page structure
       pageWrapper: 'html',
+      siteHeader: '.site-header',
+
+      // Navigation
+      mainNav: '.main-navigation',
+      navigationList: 'ul.navbar-nav',
       navToggle: '.mainnav-toggle',
-      searchToggle: '.searchbox-toggle',
-      headerSearch: '.header-search',
-      searchInput: 'input.search-query',
-      mainNav: '.main-navigation ul.navbar-nav',
-      menuLevel1: '.menu_level_1',
       navActiveClass: 'mainnav-active',
-      searchboxActiveClass: 'searchbox-active',
-      submenuTriggerElement: 'i',
+      languageSelector: '.language-selector',
+
+      // Submenus
+      menuLevel1: '.menu_level_1',
+      submenuTriggerElement: 'button',
       submenuTriggerClass: 'submenu-trigger',
       submenuDataParam: 'submenu',
       submenuActiveClass: 'submenu-active',
-      navigationList: 'ul.nav.navbar-nav',
+      disableSubmenuTriggers: '.no-triggers',
+
+      // Search
+      searchToggle: '.searchbox-toggle',
+      headerSearch: '.header-search',
+      searchInput: 'input.search-query',
+      searchboxActiveClass: 'searchbox-active',
       filledClass: 'filled',
-      languageSelector: '.site-header .language-selector',
-      stickyHeader: '.site-header-sticky',
     },
   },
   {

--- a/assets/sass/_accessibility.scss
+++ b/assets/sass/_accessibility.scss
@@ -49,8 +49,3 @@ button {
         @include custom-outline;
     }
 }
-
-.sr-only {
-    position: absolute;
-    left: -9999px;
-}

--- a/assets/sass/_globals.scss
+++ b/assets/sass/_globals.scss
@@ -13,7 +13,7 @@ body {
 
 // Global styles
 body:has(.site-header-fixed),
-body:has(.site-header-sticky--active) {
+body:has(.site-header-sticky.scrolled) {
     padding-top: var(--header-height);
 }
 

--- a/assets/sass/layout/_footer.scss
+++ b/assets/sass/layout/_footer.scss
@@ -22,9 +22,20 @@
             justify-content: center;
             margin: 0 0 1.5rem;
             padding: 0;
-            a {
+            a,
+            span,
+            .submenu-trigger {
                 @include text-link;
                 padding: .5em 1.1428571429em;
+            }
+            a,
+            span {
+                display: inline-block;
+            }
+            .menu_level_1 {
+                list-style-type: none;
+                padding: .5rem 0;
+                margin: 0;
             }
         }
     }
@@ -75,9 +86,6 @@
                         opacity: .66;
                     }
                 }
-            }
-            .tt {
-                display: none;
             }
         }
     }

--- a/assets/sass/layout/_header.scss
+++ b/assets/sass/layout/_header.scss
@@ -28,7 +28,7 @@ $header-bg: $white;
     }
 
     &.site-header-fixed,
-    &.site-header-sticky--active {
+    &.site-header-sticky.scrolled {
         position: fixed;
         width: 100%;
         top: var(--ngtoolbar-height, 0);

--- a/assets/sass/layout/_navigation.scss
+++ b/assets/sass/layout/_navigation.scss
@@ -11,32 +11,78 @@
         > li {
             position: relative;
             > a,
-            > span {
+            > span,
+            > .submenu-trigger {
                 @extend %hover-underline;
                 @include text-link;
                 display: inline-block;
                 padding: 0 1.3333333333em;
+            }
+            .submenu-trigger {
+                position: relative;
+                padding-right: 1.75em;
+            }
+            > a + .submenu-trigger {
+                padding-left: .25em;
+            }
+            &:has(> a + .submenu-trigger) {
+                padding-right: 2em;
+                .submenu-trigger {
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                    width: 2em;
+                    display: block;
+                }
             }
         }
     }
     /* main submenu */
     .menu_level_1 {
         list-style-type: none;
-        padding: 1rem 0;
+        padding: .5rem 0;
         margin: 0;
-        display: none;
+        visibility: hidden;
+        opacity: 0;
+        transform: translateY(-.25rem) scaleY(.85);
+        transform-origin: top;
+        transition: .1s;
         a {
             display: block;
             padding: .5em 1.5em;
         }
     }
+    .submenu-active {
+        > .menu_level_1 {
+            visibility: visible;
+            opacity: 1;
+            transform: translateY(0) scaleY(1);
+        }
+    }
+    .submenu-trigger {
+        &::before {
+            content: '';
+            position: absolute;
+            right: .75em;
+            top: 50%;
+            transform: translateY(-50%);
+            width: .625em;
+            height: .625em;
+            background-color: currentColor;
+            mask: url(../assets/icons/angle-down.svg) no-repeat center;
+            mask-size: contain;
+            transition: .15s;
+        }
+    }
     /* large screen sizes */
     @include media-breakpoint-up($collapse-nav) {
         .navbar-nav {
+            > li:has(.submenu-active),
             > li:hover,
             .active {
                 > a,
-                > span {
+                > span,
+                > .submenu-trigger {
                     color: $black;
                     &::after {
                         transform: scaleY(1);
@@ -45,17 +91,18 @@
             }
             > li {
                 > a,
-                > span {
+                > span,
+                > .submenu-trigger {
                     display: flex;
                     height: $header-height;
                     align-items: center;
                     justify-content: center;
                     color: $gray-54;
                 }
-                &:hover {
-                    .menu_level_1 {
-                        display: block;
-                    }
+            }
+            > li.submenu-active {
+                .submenu-trigger::before {
+                    transform: translateY(-60%) rotate(180deg);
                 }
             }
         }
@@ -75,13 +122,14 @@
             }
         }
     }
-    .submenu-trigger {
-        // NOTE: Removed fontawesome extend rule since the nav will we rewritten
-        display: none;
-    }
     /* small screen sizes */
     @include media-breakpoint-down($collapse-nav) {
-        display: none;
+        display: flex;
+        flex-direction: column;
+        visibility: hidden;
+        opacity: 0;
+        transform: scale(.95);
+        transition: .1s;
         position: absolute;
         left: calc(var(--bs-gutter-x) * .5);
         right: calc(var(--bs-gutter-x) * .5);
@@ -95,52 +143,53 @@
             padding: 1rem 0;
             > li {
                 > a,
-                > span {
+                > span,
+                > .submenu-trigger {
                     padding: .5em 1em;
                     color: $gray-87;
                     &::after {
                         display: none;
                     }
                 }
-                &[data-submenu='true'] {
-                    > a {
-                        margin: 0 1.875rem;
-                    }
+                .submenu-trigger {
+                    padding-right: 2em;
                 }
                 &.submenu-active {
                     .menu_level_1 {
-                        display: block;
+                        max-height: var(--max-height);
                     }
                     .submenu-trigger {
                         &::before {
-                            transform: rotate(180deg);
+                            transform: translateY(-60%) rotate(180deg);
                         }
+                    }
+                }
+                &:has(> a + .submenu-trigger) {
+                    padding-right: 0;
+                    .submenu-trigger {
+                        position: relative;
+                        height: 1.5em;
+                        display: inline-block;
                     }
                 }
             }
         }
         .mainnav-active & {
-            display: block;
+            visibility: visible;
+            opacity: 1;
+            transform: scale(1);
         }
         .submenu-trigger {
-            display: inline-block;
-            position: absolute;
             right: 0;
             top: 0;
-            cursor: pointer;
-            width: 1.875rem;
-            height: 1.875rem;
-            line-height: 1.875rem;
-            @include text-0_875;
-            &::before {
-                display: block;
-                content: '\f078';
-            }
         }
         .menu_level_1 {
-            padding: 0 0 1rem;
+            max-height: 0;
+            overflow: hidden;
+            padding: 0;
+            transform: translateY(-.25rem);
+            transition: .25s;
             a {
-                color: $gray-54;
                 @include text-0_875;
             }
         }
@@ -156,6 +205,17 @@
     @include media-breakpoint-down(xs) {
         left: 0;
         right: 0;
+    }
+}
+
+.submenu-trigger {
+    text-align: inherit;
+    color: inherit;
+    background-color: transparent;
+    border: 0;
+    .no-triggers &::after,
+    .no-triggers a + & {
+        display: none;
     }
 }
 

--- a/templates/themes/app/forms/theme.html.twig
+++ b/templates/themes/app/forms/theme.html.twig
@@ -155,7 +155,7 @@
         <label class="form-label{% if required %} required{% endif %}" for={{ id }}>{{ ngparams.label|default(label|trans(label_translation_parameters, translation_domain)|default('File'))|raw }}
             {% if required %}
                 <span aria-hidden="true">*</span>
-                <span class="sr-only">{{ 'ngsite.collected_info.mandatory_field'|trans }}</span>
+                <span class="visually-hidden">{{ 'ngsite.collected_info.mandatory_field'|trans }}</span>
             {% endif %}
         </label>
         {{- form_widget(form) -}}
@@ -275,7 +275,7 @@
 
             {% if required %}
                 <span aria-hidden="true">*</span>
-                <span class="sr-only">{{ 'ngsite.collected_info.mandatory_field'|trans }}</span>
+                <span class="visually-hidden">{{ 'ngsite.collected_info.mandatory_field'|trans }}</span>
             {% endif %}
         </{{ element|default('label') }}>
     {%- endif -%}
@@ -325,7 +325,7 @@
 
                 {% if required %}
                     <span aria-hidden="true">*</span>
-                    <span class="sr-only">{{ 'ngsite.collected_info.mandatory_field'|trans }}</span>
+                    <span class="visually-hidden">{{ 'ngsite.collected_info.mandatory_field'|trans }}</span>
                 {% endif %}
 
             {%- endif -%}

--- a/templates/themes/app/modules/knp_menu/menu.html.twig
+++ b/templates/themes/app/modules/knp_menu/menu.html.twig
@@ -43,12 +43,25 @@
         {%- endif %}
         {# END NGSTACK-448 #}
 
+        {# Generate unique submenu ID for ARIA attributes #}
+        {%- if item.hasChildren and options.depth is not same as(0) and item.displayChildren %}
+            {%- if item.extras.ibexa_location is defined and item.extras.ibexa_location is not empty %}
+                {%- set submenuId = 'submenu-' ~ item.extras.ibexa_location.id %}
+            {%- else %}
+                {%- set submenuId = 'submenu-' ~ item.name|lower|replace({' ': '-', '_': '-'}) %}
+            {%- endif %}
+        {%- endif %}
+
         {# displaying the item #}
         {% import _self as knp_menu %}
         <li{{ knp_menu.attributes(attributes) }}>
             {%- if item.uri is not empty and (not matcher.isCurrent(item) or options.currentAsLink) %}
                 {{ block('linkElement') }}
+            {%- elseif submenuId is defined %}
+                {# Item has submenu - use button for accessibility #}
+                <button class="submenu-trigger" aria-haspopup="menu" aria-expanded="false" aria-controls="{{ submenuId }}">{{ block('label') }}</button>
             {%- else %}
+                {# Item has no link and no submenu - fallback to span #}
                 {{ block('spanElement') }}
             {%- endif %}
 
@@ -56,6 +69,9 @@
             {%- set childrenClasses = item.childrenAttribute('class') is not empty ? [item.childrenAttribute('class')] : [] %}
             {%- set childrenClasses = childrenClasses|merge(['menu_level_' ~ item.level]) %}
             {%- set listAttributes = item.childrenAttributes|merge({'class': childrenClasses|join(' ') }) %}
+            {%- if submenuId is defined %}
+                {%- set listAttributes = listAttributes|merge({'id': submenuId, 'aria-hidden': 'true'}) %}
+            {%- endif %}
 
             {{ block('list') }}
         </li>

--- a/templates/themes/app/modules/knp_menu/menu.html.twig
+++ b/templates/themes/app/modules/knp_menu/menu.html.twig
@@ -44,6 +44,7 @@
         {# END NGSTACK-448 #}
 
         {# Generate unique submenu ID for ARIA attributes #}
+        {%- set submenuId = null %}
         {%- if item.hasChildren and options.depth is not same as(0) and item.displayChildren %}
             {%- if item.extras.ibexa_location is defined and item.extras.ibexa_location is not empty %}
                 {%- set submenuId = 'submenu-' ~ item.extras.ibexa_location.id %}
@@ -57,7 +58,7 @@
         <li{{ knp_menu.attributes(attributes) }}>
             {%- if item.uri is not empty and (not matcher.isCurrent(item) or options.currentAsLink) %}
                 {{ block('linkElement') }}
-            {%- elseif submenuId is defined %}
+            {%- elseif submenuId is not empty %}
                 {# Item has submenu - use button for accessibility #}
                 <button class="submenu-trigger" aria-haspopup="menu" aria-expanded="false" aria-controls="{{ submenuId }}">{{ block('label') }}</button>
             {%- else %}
@@ -69,7 +70,7 @@
             {%- set childrenClasses = item.childrenAttribute('class') is not empty ? [item.childrenAttribute('class')] : [] %}
             {%- set childrenClasses = childrenClasses|merge(['menu_level_' ~ item.level]) %}
             {%- set listAttributes = item.childrenAttributes|merge({'class': childrenClasses|join(' ') }) %}
-            {%- if submenuId is defined %}
+            {%- if submenuId is not empty %}
                 {%- set listAttributes = listAttributes|merge({'id': submenuId, 'aria-hidden': 'true'}) %}
             {%- endif %}
 

--- a/templates/themes/app/pagelayout/footer.html.twig
+++ b/templates/themes/app/pagelayout/footer.html.twig
@@ -4,7 +4,7 @@
     <div class="container">
         {% include '@ibexadesign/content/parts/site_logo.html.twig' %}
 
-        <div class="footer-menu">
+        <div class="footer-menu no-triggers">
             {% block page_additional_menu_footer %}
                 {{ render_esi(
                     controller(
@@ -22,7 +22,7 @@
                     <li>
                         <a href="{{ site_info.fields.facebook.value.link }}" aria-label="{{ 'ngsite.visit_us_on_facebook'|trans }}"  target="_blank" noreferrer noopener >
                             <i class="icon-facebook"></i>
-                            <span class="tt">Facebook</span>
+                            <span class="visually-hidden">Facebook</span>
                         </a>
                     </li>
                 {% endif %}
@@ -31,7 +31,7 @@
                     <li>
                         <a href="{{ site_info.fields.twitter.value.link }}" aria-label="{{ 'ngsite.visit_us_on_twitter'|trans }}"  target="_blank" noreferrer noopener >
                             <i class="icon-twitter"></i>
-                            <span class="tt">Twitter</span>
+                            <span class="visually-hidden">Twitter</span>
                         </a>
                     </li>
                 {% endif %}
@@ -40,7 +40,7 @@
                     <li>
                         <a href="{{ site_info.fields.instagram.value.link }}" aria-label="{{ 'ngsite.visit_us_on_instagram'|trans }}" target="_blank" noreferrer noopener >
                             <i class="icon-instagram"></i>
-                            <span class="tt">Instagram</span>
+                            <span class="visually-hidden">Instagram</span>
                         </a>
                     </li>
                 {% endif %}
@@ -49,7 +49,7 @@
                     <li>
                         <a href="{{ site_info.fields.linkedin.value.link }}" aria-label="{{ 'ngsite.visit_us_on_linkedin'|trans }}"  target="_blank" noreferrer noopener >
                             <i class="icon-linkedin"></i>
-                            <span class="tt">LinkedIn</span>
+                            <span class="visually-hidden">LinkedIn</span>
                         </a>
                     </li>
                 {% endif %}

--- a/templates/themes/app/pagelayout/header/search_box.html.twig
+++ b/templates/themes/app/pagelayout/header/search_box.html.twig
@@ -1,11 +1,11 @@
 <div class="header-search">
     <a class="searchbox-toggle" href="{{ path('ngsite_content_search') }}" title="{{ 'ngsite.layout.search'|trans }}" aria-expanded="false" aria-controls="site-wide-search">
         <i class="icon-search" aria-hidden="true"></i>
-        <span class="sr-only">{{ 'ngsite.layout.search'|trans }}</span>
+        <span class="visually-hidden">{{ 'ngsite.layout.search'|trans }}</span>
     </a>
 
     <form class="navbar-search" method="get" action="{{ path('ngsite_content_search') }}" id="site-wide-search">
-        <label for="site-wide-search-field" class="sr-only">{{ 'ngsite.layout.search'|trans }}</label>
+        <label for="site-wide-search-field" class="visually-hidden">{{ 'ngsite.layout.search'|trans }}</label>
         <input
             class="search-query"
             type="search"


### PR DESCRIPTION
This one is huge, sorry. The main purpose was to avoid opening menus on hover, have a consistent click/tap interaction, use proper elements for the submenu triggers, with proper ARIA attributes to comply with the best accessibility practices. Found few more issues along the way as usual.


### Accessibility Improvements
- **Submenu triggers**: Changed from `<i>` to semantic `<button>` elements with proper ARIA attributes (`aria-haspopup`, `aria-expanded`, `aria-controls`)
- **Submenu lists**: Added `aria-hidden` state management and unique IDs for ARIA references
- **Screen reader text**: Standardized to Bootstrap's `.visually-hidden` class (replaced deprecated `.sr-only` and custom `.tt` which was useless anyway)
- **Keyboard support**: Submenu triggers are now focusable with keyboard, submenus can be opened with Space/Enter and closed with Escape key
- **Mobile nav**: Added `aria-hidden` toggle when navigation opens/closes, on page load set to true

### UX Enhancements
- **Submenu animations**: Added smooth CSS transitions (opacity, transform) for submenu open/close (if not needed, transitions can be simply removed from the styles)
- **Mobile submenus**: Improved expand/collapse animation using `max-height` (utility function `setSubmenuMaxHeight` in JS)
- **Mobile navigation**: When toggled and body is set to position fixed, negative top offset it set to stay visually on the same scroll position, not jumping anywhere
- **Active state**: Parent submenus auto-expand on mobile when child item is active

### Code Refactoring
- **PageHeader component**: Reorganized with better structure, single delegated click handler for submenus
- **Sticky header**: Simplified class from `site-header-sticky--active` to `site-header-sticky.scrolled`
- **Footer**: Added `no-triggers` class to disable interactive submenu triggers where not needed

### Files Changed
- `PageHeader.component.js` - Major refactor
- `_navigation.scss` - Animation and button trigger styles
- `menu.html.twig` - ARIA attributes and button triggers
- `footer.html.twig`, `search_box.html.twig`, `forms/theme.html.twig` - Screen reader class updates

### Notes
- There is this `no-triggers` class, which effectively changes the child submenu-trigger to a plain heading for the subitems. This can be useful for the cases where the subitems should be displayed directly, and not in interactive menu (typically in the footer, based on my experience).
- The `isMobile` breakpoint in JS has to be kept in sync with the SCSS breakpoint variables, as I noted in the code
- I adjusted the code for the sticky header, so now the `scrolled` class is added to site header regardless its relative, fixed, or sticky position. This should be simpler and more universal solution, enabling easy styling if needed (e.g. styling fixed header differently if scrolled). And the BEM syntax wasn't use anywhere else, anyway